### PR TITLE
Future (future) RStan Compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RoBTT
 Title: Robust Bayesian T-Test
-Version: 1.0.1
+Version: 1.0.3
 Maintainer: František Bartoš <f.bartos96@gmail.com>
 Authors@R: c( 
     person("František", "Bartoš",     role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,2 +1,6 @@
+## version 1.0.3
+Compatibility update for the rstan 2.31.
+(correct CRAN commit)
+
 ## version 1.0.1
 Compatibility update for the rstan 2.26.

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -78,6 +78,8 @@ assign("max_cores",       parallel::detectCores(logical = TRUE) - 1,  envir = Ro
     paste0(RoBTT.version, collapse = "."),
     "1.0.0" = c("0.2.12", "999.999.999"),
     "1.0.1" = c("0.2.12", "999.999.999"),
+    "1.0.2" = c("0.2.12", "999.999.999"),
+    "1.0.3" = c("0.2.12", "999.999.999"),
     stop("New RoBTT version needs to be defined in '.check_BayesTools' function!")
   )
   

--- a/inst/stan/beta.stan
+++ b/inst/stan/beta.stan
@@ -35,8 +35,8 @@ data {
 parameters{
   real<lower = 0, upper = 1> mu;
   real<lower = 0> sigma2;
-  real<lower = coefs_lb(bounds_type_d[1], bounds_d[1]), upper = coefs_ub(bounds_type_d[2], bounds_d[2])> delta[is_d];
-  real<lower = coefs_lb(bounds_type_r[1], bounds_r[1]), upper = coefs_ub(bounds_type_r[2], bounds_r[2])> rho[is_r];
+  real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta[is_d];
+  real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho[is_r];
 }
 transformed parameters {
   real pooled_sigma;

--- a/inst/stan/gamma.stan
+++ b/inst/stan/gamma.stan
@@ -35,8 +35,8 @@ data {
 parameters{
   real<lower = 0> mu;
   real<lower = 0> sigma2;
-  real<lower = coefs_lb(bounds_type_d[1], bounds_d[1]), upper = coefs_ub(bounds_type_d[2], bounds_d[2])> delta[is_d];
-  real<lower = coefs_lb(bounds_type_r[1], bounds_r[1]), upper = coefs_ub(bounds_type_r[2], bounds_r[2])> rho[is_r];
+  real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta[is_d];
+  real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho[is_r];
 }
 transformed parameters {
   real pooled_sigma;

--- a/inst/stan/include/common_functions.stan
+++ b/inst/stan/include/common_functions.stan
@@ -17,13 +17,13 @@ functions {
   real coefs_lb(int[] type_in, vector bound_in) {
     int type;
     real bound;
+    real lb;
     if (num_elements(type_in) == 0) {
       return negative_infinity();
     } else {
       type = type_in[1];
       bound = bound_in[1];
     }
-    real lb;
     if (type == 0)
       lb = negative_infinity();
     else
@@ -33,13 +33,13 @@ functions {
   real coefs_ub(int[] type_in, vector bound_in) {
     int type;
     real bound;
+    real lb;
     if (num_elements(type_in) == 0) {
       return positive_infinity();
     } else {
       type = type_in[2];
       bound = bound_in[2];
     }
-    real lb;
     if (type == 0)
       lb = positive_infinity();
     else

--- a/inst/stan/include/common_functions.stan
+++ b/inst/stan/include/common_functions.stan
@@ -1,5 +1,5 @@
 functions {
-  
+
  // default Jeffrey priors for sigma and mu
   real Jeffreys_mu_lpdf(real mu){
     return 0;
@@ -14,7 +14,15 @@ functions {
   }
 
   // function for setting parameter bounds
-  real coefs_lb(int type, real bound) {
+  real coefs_lb(int[] type_in, vector bound_in) {
+    int type;
+    real bound;
+    if (num_elements(type_in) == 0) {
+      return negative_infinity();
+    } else {
+      type = type_in[1];
+      bound = bound_in[1];
+    }
     real lb;
     if (type == 0)
       lb = negative_infinity();
@@ -22,7 +30,15 @@ functions {
       lb = bound;
     return lb;
   }
-  real coefs_ub(int type, real bound) {
+  real coefs_ub(int[] type_in, vector bound_in) {
+    int type;
+    real bound;
+    if (num_elements(type_in) == 0) {
+      return positive_infinity();
+    } else {
+      type = type_in[2];
+      bound = bound_in[2];
+    }
     real lb;
     if (type == 0)
       lb = positive_infinity();

--- a/inst/stan/lognormal.stan
+++ b/inst/stan/lognormal.stan
@@ -35,8 +35,8 @@ data {
 parameters{
   real<lower = 0> mu;
   real<lower = 0> sigma2;
-  real<lower = coefs_lb(bounds_type_d[1], bounds_d[1]), upper = coefs_ub(bounds_type_d[2], bounds_d[2])> delta[is_d];
-  real<lower = coefs_lb(bounds_type_r[1], bounds_r[1]), upper = coefs_ub(bounds_type_r[2], bounds_r[2])> rho[is_r];
+  real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta[is_d];
+  real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho[is_r];
 }
 transformed parameters {
   real pooled_sigma;

--- a/inst/stan/normal.stan
+++ b/inst/stan/normal.stan
@@ -35,8 +35,8 @@ data {
 parameters{
   real mu;
   real<lower = 0> sigma2;
-  real<lower = coefs_lb(bounds_type_d[1], bounds_d[1]), upper = coefs_ub(bounds_type_d[2], bounds_d[2])> delta[is_d];
-  real<lower = coefs_lb(bounds_type_r[1], bounds_r[1]), upper = coefs_ub(bounds_type_r[2], bounds_r[2])> rho[is_r];
+  real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta[is_d];
+  real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho[is_r];
 }
 transformed parameters {
   real pooled_sigma;

--- a/inst/stan/t.stan
+++ b/inst/stan/t.stan
@@ -41,9 +41,9 @@ data {
 parameters{
   real mu;
   real<lower = 0> sigma2;
-  real<lower = coefs_lb(bounds_type_d[1],  bounds_d[1]),  upper = coefs_ub(bounds_type_d[2],  bounds_d[2])>  delta[is_d];
-  real<lower = coefs_lb(bounds_type_r[1],  bounds_r[1]),  upper = coefs_ub(bounds_type_r[2],  bounds_r[2])>  rho[is_r];
-  real<lower = coefs_lb(bounds_type_nu[1], bounds_nu[1]), upper = coefs_ub(bounds_type_nu[2], bounds_nu[2])> nu_p[is_nu];
+  real<lower = coefs_lb(bounds_type_d,  bounds_d),  upper = coefs_ub(bounds_type_d,  bounds_d)>  delta[is_d];
+  real<lower = coefs_lb(bounds_type_r,  bounds_r),  upper = coefs_ub(bounds_type_r,  bounds_r)>  rho[is_r];
+  real<lower = coefs_lb(bounds_type_nu, bounds_nu), upper = coefs_ub(bounds_type_nu, bounds_nu)> nu_p[is_nu];
 }
 transformed parameters {
   real pooled_sigma;


### PR DESCRIPTION
Apologies for an additional PR so soon! We're currently testing package compatibility with the bleeding-edge rstan (2.31, aligned with current cmdstan) and there's been a failure due to the Stan code in your package.

When setting lower/upper bounds for some parameters, your models are using:
```
lower = coefs_lb(bounds_type_d[1], bounds_d[1])
```

However, the `bounds_type_d` and `bounds_d` objects (or the `_r` equivalent) can be of size 0 and this causes an indexing error under the latest version of Stan. The PR updates the `coefs_lb` and `coefs_ub` functions to take the objects in full and detect whether they are size zero or not before indexing them for the bounds.

Let me know if you have any questions/concerns. Thanks!