### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RoBTT
 Title: Robust Bayesian T-Test
-Version: 1.2.0
+Version: 1.2.1
 Maintainer: František Bartoš <f.bartos96@gmail.com>
 Authors@R: c( 
     person("František", "Bartoš",     role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,8 +30,8 @@ RoxygenNote: 7.2.3
 NeedsCompilation: yes
 ByteCompile: true
 LinkingTo: 
-    StanHeaders (>= 2.18.1),
-    rstan (>= 2.21.2),
+    StanHeaders (>= 2.26.0),
+    rstan (>= 2.26.0),
     BH (>= 1.69.0),
     Rcpp (>= 0.12.15),
     RcppEigen (>= 0.3.3.4.0),
@@ -40,7 +40,7 @@ Depends:
     R (>= 4.0.0),
     Rcpp (>= 0.12.19)
 Imports:
-    rstan(>= 2.21.2),
+    rstan(>= 2.26.0),
     rstantools(>= 1.5.0),
     RcppParallel (>= 5.0.1),
     BayesTools (>= 0.2.15),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## version 1.2.1
+Compatibility update for the rstan 2.26.
+
 ## version 1.2.0
 ### Changes
 - when specifying prior distribution for the nu parameter, coerce Spike(Inf) to NULL

--- a/R/main.R
+++ b/R/main.R
@@ -70,7 +70,7 @@
 #'
 #' @return \code{RoBTT} returns an object of \link[base]{class} \code{"RoBTT"}.
 #'
-#' @examples
+#' @examples \dontrun{
 #' # using the example data from Darwin
 #' data("fertilization", package = "RoBTT")
 #' fit <- RoBTT(
@@ -87,7 +87,8 @@
 #'
 #' # summary can provide many details about the model
 #' summary(fit)
-#'
+#' }
+#' 
 #' @references
 #' \insertAllCited{}
 #' @export RoBTT

--- a/R/plot.R
+++ b/R/plot.R
@@ -33,7 +33,7 @@
 #' x-label, y-label, title, x-axis range, and y-axis range
 #' respectively.
 #'
-#' @examples 
+#' @examples \dontrun{
 #' data("fertilization", package = "RoBTT")
 #' fit <- RoBTT(
 #'   x1       = fertilization$Self,
@@ -52,6 +52,7 @@
 #' 
 #' # plot prior and posterior of the conditional effect size estimate
 #' plot(fit, parameter = "delta", conditional = TRUE, prior = TRUE)
+#' }
 #' 
 #' @return \code{plot.RoBTT} returns either \code{NULL} if \code{plot_type = "base"}
 #' or an object object of class 'ggplot2' if \code{plot_type = "ggplot2"}.

--- a/R/summary.R
+++ b/R/summary.R
@@ -41,7 +41,7 @@ print.RoBTT <- function(x, ...){
 #' be omitted from the summary. Defaults to \code{FALSE}.
 #' @param ... additional arguments
 #'
-#' @examples
+#' @examples \dontrun{
 #' # using the example data from Darwin
 #' data("fertilization", package = "RoBTT")
 #' fit <- RoBTT(
@@ -72,7 +72,7 @@ print.RoBTT <- function(x, ...){
 #'
 #' # summary of individual models and their parameters can be further obtained by
 #' summary(fit, type = "individual")
-#'
+#' }
 #'
 #' @return \code{summary.RoBTT} returns a list of tables of class 'BayesTools_table'.
 #'

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -82,6 +82,7 @@ assign("max_cores",       parallel::detectCores(logical = TRUE) - 1,  envir = Ro
     "1.0.3" = c("0.2.12", "999.999.999"),
     "1.1.0" = c("0.2.14", "999.999.999"),
     "1.2.0" = c("0.2.15", "999.999.999"),
+    "1.2.1" = c("0.2.15", "999.999.999"),
     stop("New RoBTT version needs to be defined in '.check_BayesTools' function!")
   )
   

--- a/inst/stan/beta.stan
+++ b/inst/stan/beta.stan
@@ -21,8 +21,8 @@ data {
   // range of the parameters
   vector[is_d == 1 ? 2 : 0] bounds_d;
   vector[is_r == 1 ? 2 : 0] bounds_r;
-  int bounds_type_d[is_d == 1 ? 2 : 0];
-  int bounds_type_r[is_r == 1 ? 2 : 0];
+  array[is_d == 1 ? 2 : 0] int bounds_type_d;
+  array[is_r == 1 ? 2 : 0] int bounds_type_r;
 
   // prior distribution specification of the parameteres
   vector[is_d == 0 ? 1 : 0] fixed_d;
@@ -35,8 +35,8 @@ data {
 parameters{
   real<lower = 0, upper = 1> mu;
   real<lower = 0> sigma2;
-  real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta[is_d];
-  real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho[is_r];
+  array[is_d] real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta;
+  array[is_r] real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho;
 }
 transformed parameters {
   real pooled_sigma;

--- a/inst/stan/gamma.stan
+++ b/inst/stan/gamma.stan
@@ -21,8 +21,8 @@ data {
   // range of the parameters
   vector[is_d == 1 ? 2 : 0] bounds_d;
   vector[is_r == 1 ? 2 : 0] bounds_r;
-  int bounds_type_d[is_d == 1 ? 2 : 0];
-  int bounds_type_r[is_r == 1 ? 2 : 0];
+  array[is_d == 1 ? 2 : 0] int bounds_type_d;
+  array[is_r == 1 ? 2 : 0] int bounds_type_r;
 
   // prior distribution specification of the parameteres
   vector[is_d == 0 ? 1 : 0] fixed_d;
@@ -35,8 +35,8 @@ data {
 parameters{
   real<lower = 0> mu;
   real<lower = 0> sigma2;
-  real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta[is_d];
-  real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho[is_r];
+  array[is_d] real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta;
+  array[is_r] real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho;
 }
 transformed parameters {
   real pooled_sigma;

--- a/inst/stan/include/common_functions.stan
+++ b/inst/stan/include/common_functions.stan
@@ -14,7 +14,7 @@ functions {
   }
 
   // function for setting parameter bounds
-  real coefs_lb(int[] type_in, vector bound_in) {
+  real coefs_lb(array[] int type_in, vector bound_in) {
     int type;
     real bound;
     real lb;
@@ -30,7 +30,7 @@ functions {
       lb = bound;
     return lb;
   }
-  real coefs_ub(int[] type_in, vector bound_in) {
+  real coefs_ub(array[] int type_in, vector bound_in) {
     int type;
     real bound;
     real lb;
@@ -56,7 +56,7 @@ functions {
   // type 6 = inverse-gamma
   // type 7 = uniform
   // type 8 = beta
-  real set_prior(real parameter, int prior_type, vector prior_parameters, int[] bounds_type, vector bounds){
+  real set_prior(real parameter, int prior_type, vector prior_parameters, array[] int bounds_type, vector bounds){
     real ll;
 
     if(prior_type == 1){

--- a/inst/stan/lognormal.stan
+++ b/inst/stan/lognormal.stan
@@ -21,8 +21,8 @@ data {
   // range of the parameters
   vector[is_d == 1 ? 2 : 0] bounds_d;
   vector[is_r == 1 ? 2 : 0] bounds_r;
-  int bounds_type_d[is_d == 1 ? 2 : 0];
-  int bounds_type_r[is_r == 1 ? 2 : 0];
+  array[is_d == 1 ? 2 : 0] int bounds_type_d;
+  array[is_r == 1 ? 2 : 0] int bounds_type_r;
 
   // prior distribution specification of the parameteres
   vector[is_d == 0 ? 1 : 0] fixed_d;
@@ -35,8 +35,8 @@ data {
 parameters{
   real<lower = 0> mu;
   real<lower = 0> sigma2;
-  real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta[is_d];
-  real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho[is_r];
+  array[is_d] real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta;
+  array[is_r] real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho;
 }
 transformed parameters {
   real pooled_sigma;

--- a/inst/stan/normal.stan
+++ b/inst/stan/normal.stan
@@ -21,8 +21,8 @@ data {
   // range of the parameters
   vector[is_d == 1 ? 2 : 0] bounds_d;
   vector[is_r == 1 ? 2 : 0] bounds_r;
-  int bounds_type_d[is_d == 1 ? 2 : 0];
-  int bounds_type_r[is_r == 1 ? 2 : 0];
+  array[is_d == 1 ? 2 : 0] int bounds_type_d;
+  array[is_r == 1 ? 2 : 0] int bounds_type_r;
 
   // prior distribution specification of the parameteres
   vector[is_d == 0 ? 1 : 0] fixed_d;
@@ -35,8 +35,8 @@ data {
 parameters{
   real mu;
   real<lower = 0> sigma2;
-  real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta[is_d];
-  real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho[is_r];
+  array[is_d] real<lower = coefs_lb(bounds_type_d, bounds_d), upper = coefs_ub(bounds_type_d, bounds_d)> delta;
+  array[is_r] real<lower = coefs_lb(bounds_type_r, bounds_r), upper = coefs_ub(bounds_type_r, bounds_r)> rho;
 }
 transformed parameters {
   real pooled_sigma;

--- a/inst/stan/t.stan
+++ b/inst/stan/t.stan
@@ -23,14 +23,14 @@ data {
   vector[is_d  == 1 ? 2 : 0] bounds_d;
   vector[is_r  == 1 ? 2 : 0] bounds_r;
   vector[is_nu == 1 ? 2 : 0] bounds_nu;
-  int bounds_type_d[is_d   == 1 ? 2 : 0];
-  int bounds_type_r[is_r   == 1 ? 2 : 0];
-  int bounds_type_nu[is_nu == 1 ? 2 : 0];
+  array[is_d   == 1 ? 2 : 0] int bounds_type_d;
+  array[is_r   == 1 ? 2 : 0] int bounds_type_r;
+  array[is_nu == 1 ? 2 : 0] int bounds_type_nu;
 
   // prior distribution specification of the parameteres
-  real fixed_d[is_d   == 0 ? 1 : 0];
-  real fixed_r[is_r   == 0 ? 1 : 0];
-  real fixed_nu[is_nu == 0 ? 1 : 0];
+  array[is_d   == 0 ? 1 : 0] real fixed_d;
+  array[is_r   == 0 ? 1 : 0] real fixed_r;
+  array[is_nu == 0 ? 1 : 0] real fixed_nu;
   vector[is_d  == 1 ? 3 : 0] prior_parameters_d;
   vector[is_r  == 1 ? 3 : 0] prior_parameters_r;
   vector[is_nu == 1 ? 3 : 0] prior_parameters_nu;
@@ -41,15 +41,15 @@ data {
 parameters{
   real mu;
   real<lower = 0> sigma2;
-  real<lower = coefs_lb(bounds_type_d,  bounds_d),  upper = coefs_ub(bounds_type_d,  bounds_d)>  delta[is_d];
-  real<lower = coefs_lb(bounds_type_r,  bounds_r),  upper = coefs_ub(bounds_type_r,  bounds_r)>  rho[is_r];
-  real<lower = coefs_lb(bounds_type_nu, bounds_nu), upper = coefs_ub(bounds_type_nu, bounds_nu)> nu_p[is_nu];
+  array[is_d] real<lower = coefs_lb(bounds_type_d,  bounds_d),  upper = coefs_ub(bounds_type_d,  bounds_d)>  delta;
+  array[is_r] real<lower = coefs_lb(bounds_type_r,  bounds_r),  upper = coefs_ub(bounds_type_r,  bounds_r)>  rho;
+  array[is_nu] real<lower = coefs_lb(bounds_type_nu, bounds_nu), upper = coefs_ub(bounds_type_nu, bounds_nu)> nu_p;
 }
 transformed parameters {
   real pooled_sigma;
-  real sigma_i[2];
-  real scale_i[2];
-  real mu_i[2];
+  array[2] real sigma_i;
+  array[2] real scale_i;
+  array[2] real mu_i;
   real nu;
 
 

--- a/man/RoBTT.Rd
+++ b/man/RoBTT.Rd
@@ -132,6 +132,7 @@ Generic \code{\link[=summary.RoBTT]{summary.RoBTT()}}, \code{\link[=print.RoBTT]
 provided to facilitate manipulation with the ensemble.
 }
 \examples{
+\dontrun{
 # using the example data from Darwin
 data("fertilization", package = "RoBTT")
 fit <- RoBTT(
@@ -148,6 +149,7 @@ fit <- RoBTT(
 
 # summary can provide many details about the model
 summary(fit)
+}
 
 }
 \references{

--- a/man/plot.RoBTT.Rd
+++ b/man/plot.RoBTT.Rd
@@ -62,6 +62,7 @@ different \code{"RoBTT"} object parameters in various
 ways. See \code{type} for the different model types.
 }
 \examples{
+\dontrun{
 data("fertilization", package = "RoBTT")
 fit <- RoBTT(
   x1       = fertilization$Self,
@@ -80,6 +81,7 @@ plot(fit, parameter = "delta")
 
 # plot prior and posterior of the conditional effect size estimate
 plot(fit, parameter = "delta", conditional = TRUE, prior = TRUE)
+}
 
 }
 \seealso{

--- a/man/summary.RoBTT.Rd
+++ b/man/summary.RoBTT.Rd
@@ -55,6 +55,7 @@ be omitted from the summary. Defaults to \code{FALSE}.}
 RoBTT object.
 }
 \examples{
+\dontrun{
 # using the example data from Darwin
 data("fertilization", package = "RoBTT")
 fit <- RoBTT(
@@ -85,7 +86,7 @@ summary(fit, type = "diagnostics")
 
 # summary of individual models and their parameters can be further obtained by
 summary(fit, type = "individual")
-
+}
 
 }
 \seealso{

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-nu-2.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-nu-2.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='209.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='219.22' width='8.82' height='45.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='241.58' width='8.82' height='22.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='250.72' width='8.82' height='13.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='255.49' width='8.82' height='9.03' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='258.83' width='8.82' height='5.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='262.21' width='8.82' height='2.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='264.52' width='8.82' height='0.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='263.21' width='8.82' height='1.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='262.36' width='8.82' height='2.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='263.74' width='8.82' height='0.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='264.52' width='8.82' height='0.053' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='264.52' width='8.82' height='1.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='264.52' width='8.82' height='2.87' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='263.93' width='8.82' height='0.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='264.52' width='8.82' height='1.97' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='262.04' width='8.82' height='2.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='261.70' width='8.82' height='2.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='261.09' width='8.82' height='3.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='264.52' width='8.82' height='1.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='264.52' width='8.82' height='2.85' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='264.52' width='8.82' height='3.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='263.45' width='8.82' height='1.07' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='263.62' width='8.82' height='0.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='264.52' width='8.82' height='1.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='264.26' width='8.82' height='0.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='264.52' width='8.82' height='0.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='260.96' width='8.82' height='3.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='263.41' width='8.82' height='1.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='263.15' width='8.82' height='1.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='264.52' width='8.82' height='0.042' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='209.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='219.22' width='8.82' height='45.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='241.58' width='8.82' height='22.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='250.72' width='8.82' height='13.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='255.49' width='8.82' height='9.03' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='258.83' width='8.82' height='5.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='262.21' width='8.82' height='2.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='264.52' width='8.82' height='0.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='263.21' width='8.82' height='1.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='262.36' width='8.82' height='2.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='263.74' width='8.82' height='0.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='264.52' width='8.82' height='0.053' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='264.52' width='8.82' height='1.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='264.52' width='8.82' height='2.87' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='263.93' width='8.82' height='0.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='264.52' width='8.82' height='1.97' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='262.04' width='8.82' height='2.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='261.70' width='8.82' height='2.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='261.09' width='8.82' height='3.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='264.52' width='8.82' height='1.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='264.52' width='8.82' height='2.85' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='264.52' width='8.82' height='3.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='263.45' width='8.82' height='1.07' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='263.62' width='8.82' height='0.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='264.52' width='8.82' height='1.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='264.26' width='8.82' height='0.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='264.52' width='8.82' height='0.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='260.96' width='8.82' height='3.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='263.41' width='8.82' height='1.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='263.15' width='8.82' height='1.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='264.52' width='8.82' height='0.042' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='209.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='477.15' width='8.82' height='48.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='506.78' width='8.82' height='18.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='515.62' width='8.82' height='9.76' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='519.58' width='8.82' height='5.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='520.34' width='8.82' height='5.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='525.38' width='8.82' height='1.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='525.38' width='8.82' height='3.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='525.38' width='8.82' height='5.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='525.38' width='8.82' height='2.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='524.61' width='8.82' height='0.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='523.04' width='8.82' height='2.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='520.05' width='8.82' height='5.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='522.89' width='8.82' height='2.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='521.82' width='8.82' height='3.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='519.72' width='8.82' height='5.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='523.55' width='8.82' height='1.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='524.47' width='8.82' height='0.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='525.38' width='8.82' height='1.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='525.38' width='8.82' height='6.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='525.38' width='8.82' height='1.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='525.38' width='8.82' height='5.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='525.38' width='8.82' height='0.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='525.38' width='8.82' height='4.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='525.38' width='8.82' height='1.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='522.45' width='8.82' height='2.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='521.65' width='8.82' height='3.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='524.49' width='8.82' height='0.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='523.32' width='8.82' height='2.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='523.33' width='8.82' height='2.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='525.38' width='8.82' height='3.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='209.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='477.15' width='8.82' height='48.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='506.78' width='8.82' height='18.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='515.62' width='8.82' height='9.76' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='519.58' width='8.82' height='5.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='520.34' width='8.82' height='5.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='525.38' width='8.82' height='1.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='525.38' width='8.82' height='3.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='525.38' width='8.82' height='5.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='525.38' width='8.82' height='2.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='524.61' width='8.82' height='0.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='523.04' width='8.82' height='2.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='520.05' width='8.82' height='5.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='522.89' width='8.82' height='2.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='521.82' width='8.82' height='3.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='519.72' width='8.82' height='5.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='523.55' width='8.82' height='1.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='524.47' width='8.82' height='0.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='525.38' width='8.82' height='1.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='525.38' width='8.82' height='6.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='525.38' width='8.82' height='1.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='525.38' width='8.82' height='5.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='525.38' width='8.82' height='0.92' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='525.38' width='8.82' height='4.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='525.38' width='8.82' height='1.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='522.45' width='8.82' height='2.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='521.65' width='8.82' height='3.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='524.49' width='8.82' height='0.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='523.32' width='8.82' height='2.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='523.33' width='8.82' height='2.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='525.38' width='8.82' height='3.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='209.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='226.30' width='8.82' height='38.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='238.62' width='8.82' height='25.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='251.34' width='8.82' height='13.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='255.16' width='8.82' height='9.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='261.88' width='8.82' height='2.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='264.11' width='8.82' height='0.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='264.52' width='8.82' height='3.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='264.52' width='8.82' height='0.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='264.52' width='8.82' height='0.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='263.54' width='8.82' height='0.97' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='264.52' width='8.82' height='0.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='260.58' width='8.82' height='3.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='261.14' width='8.82' height='3.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='261.25' width='8.82' height='3.27' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='264.52' width='8.82' height='0.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='264.52' width='8.82' height='7.09' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='264.52' width='8.82' height='1.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='264.52' width='8.82' height='3.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='263.21' width='8.82' height='1.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='264.52' width='8.82' height='1.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='261.68' width='8.82' height='2.84' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='263.67' width='8.82' height='0.85' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='256.47' width='8.82' height='8.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='262.19' width='8.82' height='2.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='264.52' width='8.82' height='2.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='264.52' width='8.82' height='2.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='263.05' width='8.82' height='1.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='263.15' width='8.82' height='1.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='264.52' width='8.82' height='2.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='264.52' width='8.82' height='4.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='209.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='226.30' width='8.82' height='38.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='238.62' width='8.82' height='25.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='251.34' width='8.82' height='13.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='255.16' width='8.82' height='9.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='261.88' width='8.82' height='2.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='264.11' width='8.82' height='0.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='264.52' width='8.82' height='3.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='264.52' width='8.82' height='0.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='264.52' width='8.82' height='0.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='263.54' width='8.82' height='0.97' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='264.52' width='8.82' height='0.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='260.58' width='8.82' height='3.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='261.14' width='8.82' height='3.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='261.25' width='8.82' height='3.27' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='264.52' width='8.82' height='0.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='264.52' width='8.82' height='7.09' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='264.52' width='8.82' height='1.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='264.52' width='8.82' height='3.92' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='263.21' width='8.82' height='1.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='264.52' width='8.82' height='1.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='261.68' width='8.82' height='2.84' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='263.67' width='8.82' height='0.85' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='256.47' width='8.82' height='8.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='262.19' width='8.82' height='2.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='264.52' width='8.82' height='2.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='264.52' width='8.82' height='2.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='263.05' width='8.82' height='1.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='263.15' width='8.82' height='1.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='264.52' width='8.82' height='2.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='264.52' width='8.82' height='4.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='209.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='480.91' width='8.82' height='44.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='509.71' width='8.82' height='15.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='510.67' width='8.82' height='14.71' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='511.29' width='8.82' height='14.09' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='521.37' width='8.82' height='4.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='521.12' width='8.82' height='4.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='520.10' width='8.82' height='5.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='520.61' width='8.82' height='4.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='521.80' width='8.82' height='3.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='525.38' width='8.82' height='0.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='521.84' width='8.82' height='3.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='521.65' width='8.82' height='3.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='522.62' width='8.82' height='2.76' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='525.38' width='8.82' height='1.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='525.38' width='8.82' height='0.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='522.02' width='8.82' height='3.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='525.38' width='8.82' height='1.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='525.38' width='8.82' height='3.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='525.38' width='8.82' height='3.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='525.38' width='8.82' height='4.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='525.38' width='8.82' height='1.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='525.38' width='8.82' height='1.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='525.38' width='8.82' height='2.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='525.38' width='8.82' height='3.85' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='525.38' width='8.82' height='3.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='525.38' width='8.82' height='1.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='524.92' width='8.82' height='0.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='525.38' width='8.82' height='0.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='525.38' width='8.82' height='3.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='525.38' width='8.82' height='5.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='209.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='480.91' width='8.82' height='44.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='509.71' width='8.82' height='15.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='510.67' width='8.82' height='14.71' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='511.29' width='8.82' height='14.09' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='521.37' width='8.82' height='4.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='521.12' width='8.82' height='4.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='520.10' width='8.82' height='5.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='520.61' width='8.82' height='4.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='521.80' width='8.82' height='3.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='525.38' width='8.82' height='0.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='521.84' width='8.82' height='3.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='521.65' width='8.82' height='3.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='522.62' width='8.82' height='2.76' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='525.38' width='8.82' height='1.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='525.38' width='8.82' height='0.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='522.02' width='8.82' height='3.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='525.38' width='8.82' height='1.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='525.38' width='8.82' height='3.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='525.38' width='8.82' height='3.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='525.38' width='8.82' height='4.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='525.38' width='8.82' height='1.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='525.38' width='8.82' height='1.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='525.38' width='8.82' height='2.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='525.38' width='8.82' height='3.85' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='525.38' width='8.82' height='3.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='525.38' width='8.82' height='1.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='524.92' width='8.82' height='0.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='525.38' width='8.82' height='0.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='525.38' width='8.82' height='3.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='525.38' width='8.82' height='5.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-nu-4.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-nu-4.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='208.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='247.77' width='8.82' height='15.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='253.66' width='8.82' height='9.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='254.58' width='8.82' height='8.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='256.49' width='8.82' height='6.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='259.46' width='8.82' height='3.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='262.30' width='8.82' height='0.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='262.89' width='8.82' height='2.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='262.89' width='8.82' height='1.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='262.89' width='8.82' height='1.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='255.41' width='8.82' height='7.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='262.89' width='8.82' height='3.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='262.03' width='8.82' height='0.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='262.89' width='8.82' height='1.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='260.51' width='8.82' height='2.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='262.75' width='8.82' height='0.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='260.11' width='8.82' height='2.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='262.89' width='8.82' height='1.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='262.89' width='8.82' height='6.68' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='262.89' width='8.82' height='4.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='262.87' width='8.82' height='0.023' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='262.89' width='8.82' height='2.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='262.89' width='8.82' height='2.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='261.32' width='8.82' height='1.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='262.89' width='8.82' height='4.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='262.89' width='8.82' height='2.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='260.78' width='8.82' height='2.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='260.81' width='8.82' height='2.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='262.89' width='8.82' height='0.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='262.89' width='8.82' height='2.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='262.89' width='8.82' height='2.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='208.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='247.77' width='8.82' height='15.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='253.66' width='8.82' height='9.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='254.58' width='8.82' height='8.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='256.49' width='8.82' height='6.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='259.46' width='8.82' height='3.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='262.30' width='8.82' height='0.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='262.89' width='8.82' height='2.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='262.89' width='8.82' height='1.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='262.89' width='8.82' height='1.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='255.41' width='8.82' height='7.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='262.89' width='8.82' height='3.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='262.03' width='8.82' height='0.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='262.89' width='8.82' height='1.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='260.51' width='8.82' height='2.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='262.75' width='8.82' height='0.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='260.11' width='8.82' height='2.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='262.89' width='8.82' height='1.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='262.89' width='8.82' height='6.68' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='262.89' width='8.82' height='4.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='262.87' width='8.82' height='0.023' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='262.89' width='8.82' height='2.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='262.89' width='8.82' height='2.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='261.32' width='8.82' height='1.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='262.89' width='8.82' height='4.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='262.89' width='8.82' height='2.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='260.78' width='8.82' height='2.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='260.81' width='8.82' height='2.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='262.89' width='8.82' height='0.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='262.89' width='8.82' height='2.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='262.89' width='8.82' height='2.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='208.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='497.70' width='8.82' height='26.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='512.51' width='8.82' height='11.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='514.69' width='8.82' height='9.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='519.70' width='8.82' height='4.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='523.01' width='8.82' height='0.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='523.75' width='8.82' height='3.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='523.35' width='8.82' height='0.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='523.75' width='8.82' height='3.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='523.75' width='8.82' height='8.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='523.75' width='8.82' height='1.07' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='520.96' width='8.82' height='2.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='523.75' width='8.82' height='1.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='523.75' width='8.82' height='0.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='523.75' width='8.82' height='0.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='523.75' width='8.82' height='2.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='523.75' width='8.82' height='2.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='523.75' width='8.82' height='2.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='523.75' width='8.82' height='1.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='523.75' width='8.82' height='1.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='523.75' width='8.82' height='5.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='523.03' width='8.82' height='0.73' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='523.75' width='8.82' height='1.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='523.51' width='8.82' height='0.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='523.75' width='8.82' height='1.97' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='523.75' width='8.82' height='3.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='523.04' width='8.82' height='0.71' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='523.75' width='8.82' height='0.090' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='523.75' width='8.82' height='0.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='523.75' width='8.82' height='0.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='522.64' width='8.82' height='1.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='208.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='497.70' width='8.82' height='26.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='512.51' width='8.82' height='11.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='514.69' width='8.82' height='9.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='519.70' width='8.82' height='4.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='523.01' width='8.82' height='0.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='523.75' width='8.82' height='3.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='523.35' width='8.82' height='0.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='523.75' width='8.82' height='3.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='523.75' width='8.82' height='8.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='523.75' width='8.82' height='1.07' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='520.96' width='8.82' height='2.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='523.75' width='8.82' height='1.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='523.75' width='8.82' height='0.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='523.75' width='8.82' height='0.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='523.75' width='8.82' height='2.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='523.75' width='8.82' height='2.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='523.75' width='8.82' height='2.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='523.75' width='8.82' height='1.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='523.75' width='8.82' height='1.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='523.75' width='8.82' height='5.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='523.03' width='8.82' height='0.73' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='523.75' width='8.82' height='1.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='523.51' width='8.82' height='0.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='523.75' width='8.82' height='1.97' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='523.75' width='8.82' height='3.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='523.04' width='8.82' height='0.71' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='523.75' width='8.82' height='0.090' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='523.75' width='8.82' height='0.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='523.75' width='8.82' height='0.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='522.64' width='8.82' height='1.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='208.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='246.16' width='8.82' height='16.73' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='255.55' width='8.82' height='7.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='253.43' width='8.82' height='9.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='261.77' width='8.82' height='1.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='255.51' width='8.82' height='7.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='259.59' width='8.82' height='3.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='261.95' width='8.82' height='0.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='262.89' width='8.82' height='5.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='262.89' width='8.82' height='3.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='261.95' width='8.82' height='0.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='262.62' width='8.82' height='0.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='261.15' width='8.82' height='1.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='262.89' width='8.82' height='3.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='262.89' width='8.82' height='4.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='262.89' width='8.82' height='1.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='262.89' width='8.82' height='0.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='261.42' width='8.82' height='1.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='262.89' width='8.82' height='1.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='262.89' width='8.82' height='1.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='262.89' width='8.82' height='2.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='262.89' width='8.82' height='3.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='262.89' width='8.82' height='0.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='261.78' width='8.82' height='1.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='259.27' width='8.82' height='3.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='262.89' width='8.82' height='4.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='256.31' width='8.82' height='6.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='260.71' width='8.82' height='2.18' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='261.10' width='8.82' height='1.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='259.77' width='8.82' height='3.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='260.23' width='8.82' height='2.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='208.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='246.16' width='8.82' height='16.73' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='255.55' width='8.82' height='7.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='253.43' width='8.82' height='9.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='261.77' width='8.82' height='1.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='255.51' width='8.82' height='7.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='259.59' width='8.82' height='3.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='261.95' width='8.82' height='0.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='262.89' width='8.82' height='5.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='262.89' width='8.82' height='3.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='261.95' width='8.82' height='0.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='262.62' width='8.82' height='0.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='261.15' width='8.82' height='1.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='262.89' width='8.82' height='3.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='262.89' width='8.82' height='4.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='262.89' width='8.82' height='1.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='262.89' width='8.82' height='0.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='261.42' width='8.82' height='1.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='262.89' width='8.82' height='1.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='262.89' width='8.82' height='1.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='262.89' width='8.82' height='2.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='262.89' width='8.82' height='3.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='262.89' width='8.82' height='0.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='261.78' width='8.82' height='1.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='259.27' width='8.82' height='3.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='262.89' width='8.82' height='4.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='256.31' width='8.82' height='6.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='260.71' width='8.82' height='2.18' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='261.10' width='8.82' height='1.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='259.77' width='8.82' height='3.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='260.23' width='8.82' height='2.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='208.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='506.95' width='8.82' height='16.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='511.62' width='8.82' height='12.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='519.60' width='8.82' height='4.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='518.72' width='8.82' height='5.03' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='523.36' width='8.82' height='0.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='523.75' width='8.82' height='0.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='523.75' width='8.82' height='2.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='522.81' width='8.82' height='0.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='523.75' width='8.82' height='0.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='520.13' width='8.82' height='3.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='523.75' width='8.82' height='2.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='523.75' width='8.82' height='2.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='522.68' width='8.82' height='1.07' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='521.12' width='8.82' height='2.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='521.31' width='8.82' height='2.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='523.75' width='8.82' height='3.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='523.53' width='8.82' height='0.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='523.51' width='8.82' height='0.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='518.96' width='8.82' height='4.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='519.42' width='8.82' height='4.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='523.75' width='8.82' height='1.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='521.45' width='8.82' height='2.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='522.08' width='8.82' height='1.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='520.11' width='8.82' height='3.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='523.75' width='8.82' height='2.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='519.70' width='8.82' height='4.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='522.47' width='8.82' height='1.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='519.09' width='8.82' height='4.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='516.11' width='8.82' height='7.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='519.11' width='8.82' height='4.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='208.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='506.95' width='8.82' height='16.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='511.62' width='8.82' height='12.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='519.60' width='8.82' height='4.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='518.72' width='8.82' height='5.03' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='523.36' width='8.82' height='0.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='523.75' width='8.82' height='0.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='523.75' width='8.82' height='2.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='522.81' width='8.82' height='0.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='523.75' width='8.82' height='0.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='520.13' width='8.82' height='3.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='523.75' width='8.82' height='2.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='523.75' width='8.82' height='2.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='522.68' width='8.82' height='1.07' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='521.12' width='8.82' height='2.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='521.31' width='8.82' height='2.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='523.75' width='8.82' height='3.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='523.53' width='8.82' height='0.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='523.51' width='8.82' height='0.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='518.96' width='8.82' height='4.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='519.42' width='8.82' height='4.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='523.75' width='8.82' height='1.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='521.45' width='8.82' height='2.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='522.08' width='8.82' height='1.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='520.11' width='8.82' height='3.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='523.75' width='8.82' height='2.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='519.70' width='8.82' height='4.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='522.47' width='8.82' height='1.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='519.09' width='8.82' height='4.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='516.11' width='8.82' height='7.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='519.11' width='8.82' height='4.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-nu-6.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-nu-6.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='208.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='245.69' width='8.82' height='17.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='252.27' width='8.82' height='11.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='257.35' width='8.82' height='6.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='252.42' width='8.82' height='10.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='262.01' width='8.82' height='1.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='259.10' width='8.82' height='4.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='263.41' width='8.82' height='1.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='260.41' width='8.82' height='2.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='262.27' width='8.82' height='1.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='263.41' width='8.82' height='0.55' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='260.84' width='8.82' height='2.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='258.35' width='8.82' height='5.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='263.41' width='8.82' height='5.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='261.43' width='8.82' height='1.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='263.41' width='8.82' height='0.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='263.41' width='8.82' height='4.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='263.41' width='8.82' height='3.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='259.36' width='8.82' height='4.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='263.41' width='8.82' height='0.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='263.41' width='8.82' height='2.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='263.41' width='8.82' height='0.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='262.88' width='8.82' height='0.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='263.41' width='8.82' height='0.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='263.41' width='8.82' height='2.84' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='263.41' width='8.82' height='7.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='263.41' width='8.82' height='1.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='259.50' width='8.82' height='3.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='262.32' width='8.82' height='1.09' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='263.41' width='8.82' height='2.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='261.59' width='8.82' height='1.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='208.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='245.69' width='8.82' height='17.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='252.27' width='8.82' height='11.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='257.35' width='8.82' height='6.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='252.42' width='8.82' height='10.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='262.01' width='8.82' height='1.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='259.10' width='8.82' height='4.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='263.41' width='8.82' height='1.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='260.41' width='8.82' height='2.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='262.27' width='8.82' height='1.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='263.41' width='8.82' height='0.55' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='260.84' width='8.82' height='2.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='258.35' width='8.82' height='5.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='263.41' width='8.82' height='5.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='261.43' width='8.82' height='1.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='263.41' width='8.82' height='0.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='263.41' width='8.82' height='4.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='263.41' width='8.82' height='3.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='259.36' width='8.82' height='4.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='263.41' width='8.82' height='0.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='263.41' width='8.82' height='2.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='263.41' width='8.82' height='0.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='262.88' width='8.82' height='0.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='263.41' width='8.82' height='0.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='263.41' width='8.82' height='2.84' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='263.41' width='8.82' height='7.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='263.41' width='8.82' height='1.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='259.50' width='8.82' height='3.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='262.32' width='8.82' height='1.09' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='263.41' width='8.82' height='2.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='261.59' width='8.82' height='1.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='208.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='497.25' width='8.82' height='27.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='508.31' width='8.82' height='15.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='516.77' width='8.82' height='7.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='516.73' width='8.82' height='7.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='523.00' width='8.82' height='1.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='523.09' width='8.82' height='1.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='521.71' width='8.82' height='2.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='519.26' width='8.82' height='5.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='518.91' width='8.82' height='5.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='524.17' width='8.82' height='0.095' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='524.27' width='8.82' height='3.76' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='520.46' width='8.82' height='3.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='522.10' width='8.82' height='2.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='521.10' width='8.82' height='3.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='524.27' width='8.82' height='0.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='524.27' width='8.82' height='5.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='524.27' width='8.82' height='8.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='524.27' width='8.82' height='0.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='524.27' width='8.82' height='3.55' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='524.27' width='8.82' height='1.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='524.27' width='8.82' height='3.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='521.69' width='8.82' height='2.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='520.69' width='8.82' height='3.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='524.27' width='8.82' height='0.85' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='524.27' width='8.82' height='0.056' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='521.60' width='8.82' height='2.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='524.27' width='8.82' height='1.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='523.14' width='8.82' height='1.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='524.27' width='8.82' height='1.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='522.18' width='8.82' height='2.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='208.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='497.25' width='8.82' height='27.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='508.31' width='8.82' height='15.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='516.77' width='8.82' height='7.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='516.73' width='8.82' height='7.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='523.00' width='8.82' height='1.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='523.09' width='8.82' height='1.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='521.71' width='8.82' height='2.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='519.26' width='8.82' height='5.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='518.91' width='8.82' height='5.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='524.17' width='8.82' height='0.095' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='524.27' width='8.82' height='3.76' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='520.46' width='8.82' height='3.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='522.10' width='8.82' height='2.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='521.10' width='8.82' height='3.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='524.27' width='8.82' height='0.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='524.27' width='8.82' height='5.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='524.27' width='8.82' height='8.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='524.27' width='8.82' height='0.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='524.27' width='8.82' height='3.55' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='524.27' width='8.82' height='1.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='524.27' width='8.82' height='3.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='521.69' width='8.82' height='2.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='520.69' width='8.82' height='3.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='524.27' width='8.82' height='0.85' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='524.27' width='8.82' height='0.056' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='521.60' width='8.82' height='2.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='524.27' width='8.82' height='1.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='523.14' width='8.82' height='1.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='524.27' width='8.82' height='1.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='522.18' width='8.82' height='2.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='208.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='248.80' width='8.82' height='14.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='251.88' width='8.82' height='11.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='252.37' width='8.82' height='11.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='256.96' width='8.82' height='6.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='259.94' width='8.82' height='3.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='261.23' width='8.82' height='2.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='263.41' width='8.82' height='0.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='263.41' width='8.82' height='3.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='262.94' width='8.82' height='0.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='263.41' width='8.82' height='0.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='260.60' width='8.82' height='2.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='263.41' width='8.82' height='1.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='259.60' width='8.82' height='3.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='257.92' width='8.82' height='5.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='259.74' width='8.82' height='3.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='260.25' width='8.82' height='3.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='263.41' width='8.82' height='4.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='263.12' width='8.82' height='0.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='263.41' width='8.82' height='0.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='263.41' width='8.82' height='5.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='262.64' width='8.82' height='0.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='263.41' width='8.82' height='3.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='260.54' width='8.82' height='2.87' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='256.27' width='8.82' height='7.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='258.77' width='8.82' height='4.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='256.18' width='8.82' height='7.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='263.41' width='8.82' height='1.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='260.52' width='8.82' height='2.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='263.41' width='8.82' height='4.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='263.41' width='8.82' height='0.27' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='208.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='248.80' width='8.82' height='14.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='251.88' width='8.82' height='11.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='252.37' width='8.82' height='11.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='256.96' width='8.82' height='6.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='259.94' width='8.82' height='3.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='261.23' width='8.82' height='2.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='263.41' width='8.82' height='0.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='263.41' width='8.82' height='3.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='262.94' width='8.82' height='0.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='263.41' width='8.82' height='0.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='260.60' width='8.82' height='2.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='263.41' width='8.82' height='1.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='259.60' width='8.82' height='3.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='257.92' width='8.82' height='5.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='259.74' width='8.82' height='3.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='260.25' width='8.82' height='3.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='263.41' width='8.82' height='4.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='263.12' width='8.82' height='0.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='263.41' width='8.82' height='0.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='263.41' width='8.82' height='5.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='262.64' width='8.82' height='0.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='263.41' width='8.82' height='3.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='260.54' width='8.82' height='2.87' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='256.27' width='8.82' height='7.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='258.77' width='8.82' height='4.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='256.18' width='8.82' height='7.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='263.41' width='8.82' height='1.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='260.52' width='8.82' height='2.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='263.41' width='8.82' height='4.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='263.41' width='8.82' height='0.27' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='208.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='509.40' width='8.82' height='14.87' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='513.24' width='8.82' height='11.03' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='521.67' width='8.82' height='2.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='519.02' width='8.82' height='5.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='524.18' width='8.82' height='0.081' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='524.27' width='8.82' height='2.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='524.27' width='8.82' height='1.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='524.27' width='8.82' height='3.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='523.29' width='8.82' height='0.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='524.27' width='8.82' height='0.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='524.27' width='8.82' height='2.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='524.27' width='8.82' height='1.07' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='524.27' width='8.82' height='0.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='524.27' width='8.82' height='2.27' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='524.27' width='8.82' height='3.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='524.27' width='8.82' height='1.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='524.27' width='8.82' height='1.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='524.27' width='8.82' height='0.071' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='524.27' width='8.82' height='2.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='524.27' width='8.82' height='0.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='522.46' width='8.82' height='1.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='524.27' width='8.82' height='0.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='521.95' width='8.82' height='2.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='521.75' width='8.82' height='2.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='522.62' width='8.82' height='1.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='524.27' width='8.82' height='1.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='524.27' width='8.82' height='1.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='524.27' width='8.82' height='1.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='521.10' width='8.82' height='3.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='524.27' width='8.82' height='1.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='208.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='509.40' width='8.82' height='14.87' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='513.24' width='8.82' height='11.03' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='521.67' width='8.82' height='2.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='519.02' width='8.82' height='5.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='524.18' width='8.82' height='0.081' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='524.27' width='8.82' height='2.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='524.27' width='8.82' height='1.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='524.27' width='8.82' height='3.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='523.29' width='8.82' height='0.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='524.27' width='8.82' height='0.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='524.27' width='8.82' height='2.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='524.27' width='8.82' height='1.07' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='524.27' width='8.82' height='0.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='524.27' width='8.82' height='2.27' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='524.27' width='8.82' height='3.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='524.27' width='8.82' height='1.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='524.27' width='8.82' height='1.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='524.27' width='8.82' height='0.071' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='524.27' width='8.82' height='2.45' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='524.27' width='8.82' height='0.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='522.46' width='8.82' height='1.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='524.27' width='8.82' height='0.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='521.95' width='8.82' height='2.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='521.75' width='8.82' height='2.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='522.62' width='8.82' height='1.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='524.27' width='8.82' height='1.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='524.27' width='8.82' height='1.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='524.27' width='8.82' height='1.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='521.10' width='8.82' height='3.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='524.27' width='8.82' height='1.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-nu-8.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-nu-8.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='209.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='246.34' width='8.82' height='17.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='241.87' width='8.82' height='22.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='253.66' width='8.82' height='10.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='258.31' width='8.82' height='6.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='258.40' width='8.82' height='5.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='258.78' width='8.82' height='5.55' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='260.31' width='8.82' height='4.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='263.29' width='8.82' height='1.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='263.06' width='8.82' height='1.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='259.73' width='8.82' height='4.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='258.77' width='8.82' height='5.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='264.33' width='8.82' height='4.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='261.15' width='8.82' height='3.18' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='263.36' width='8.82' height='0.97' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='262.88' width='8.82' height='1.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='263.46' width='8.82' height='0.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='264.33' width='8.82' height='2.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='263.85' width='8.82' height='0.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='262.04' width='8.82' height='2.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='264.33' width='8.82' height='0.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='264.33' width='8.82' height='3.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='264.33' width='8.82' height='3.68' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='264.33' width='8.82' height='2.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='263.44' width='8.82' height='0.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='264.33' width='8.82' height='0.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='261.46' width='8.82' height='2.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='264.33' width='8.82' height='1.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='261.53' width='8.82' height='2.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='264.33' width='8.82' height='3.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='264.33' width='8.82' height='0.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='209.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='246.34' width='8.82' height='17.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='241.87' width='8.82' height='22.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='253.66' width='8.82' height='10.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='258.31' width='8.82' height='6.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='258.40' width='8.82' height='5.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='258.78' width='8.82' height='5.55' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='260.31' width='8.82' height='4.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='263.29' width='8.82' height='1.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='263.06' width='8.82' height='1.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='259.73' width='8.82' height='4.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='258.77' width='8.82' height='5.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='264.33' width='8.82' height='4.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='261.15' width='8.82' height='3.18' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='263.36' width='8.82' height='0.97' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='262.88' width='8.82' height='1.45' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='263.46' width='8.82' height='0.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='264.33' width='8.82' height='2.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='263.85' width='8.82' height='0.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='262.04' width='8.82' height='2.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='264.33' width='8.82' height='0.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='264.33' width='8.82' height='3.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='264.33' width='8.82' height='3.68' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='264.33' width='8.82' height='2.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='263.44' width='8.82' height='0.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='264.33' width='8.82' height='0.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='261.46' width='8.82' height='2.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='264.33' width='8.82' height='1.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='261.53' width='8.82' height='2.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='264.33' width='8.82' height='3.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='264.33' width='8.82' height='0.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='209.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='507.79' width='8.82' height='17.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='513.18' width='8.82' height='12.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='522.42' width='8.82' height='2.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='523.42' width='8.82' height='1.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='519.04' width='8.82' height='6.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='519.91' width='8.82' height='5.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='523.98' width='8.82' height='1.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='522.67' width='8.82' height='2.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='525.19' width='8.82' height='2.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='525.19' width='8.82' height='0.036' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='525.19' width='8.82' height='0.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='525.19' width='8.82' height='4.18' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='525.19' width='8.82' height='2.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='525.19' width='8.82' height='0.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='524.38' width='8.82' height='0.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='525.19' width='8.82' height='4.87' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='524.65' width='8.82' height='0.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='525.19' width='8.82' height='0.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='525.19' width='8.82' height='0.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='524.01' width='8.82' height='1.18' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='524.15' width='8.82' height='1.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='525.19' width='8.82' height='5.21' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='525.19' width='8.82' height='0.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='520.85' width='8.82' height='4.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='523.25' width='8.82' height='1.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='525.19' width='8.82' height='3.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='525.19' width='8.82' height='3.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='521.60' width='8.82' height='3.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='520.87' width='8.82' height='4.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='525.19' width='8.82' height='0.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='209.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='507.79' width='8.82' height='17.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='513.18' width='8.82' height='12.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='522.42' width='8.82' height='2.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='523.42' width='8.82' height='1.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='519.04' width='8.82' height='6.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='519.91' width='8.82' height='5.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='523.98' width='8.82' height='1.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='522.67' width='8.82' height='2.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='525.19' width='8.82' height='2.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='525.19' width='8.82' height='0.036' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='525.19' width='8.82' height='0.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='525.19' width='8.82' height='4.18' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='525.19' width='8.82' height='2.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='525.19' width='8.82' height='0.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='524.38' width='8.82' height='0.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='525.19' width='8.82' height='4.87' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='524.65' width='8.82' height='0.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='525.19' width='8.82' height='0.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='525.19' width='8.82' height='0.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='524.01' width='8.82' height='1.18' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='524.15' width='8.82' height='1.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='525.19' width='8.82' height='5.21' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='525.19' width='8.82' height='0.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='520.85' width='8.82' height='4.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='523.25' width='8.82' height='1.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='525.19' width='8.82' height='3.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='525.19' width='8.82' height='3.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='521.60' width='8.82' height='3.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='520.87' width='8.82' height='4.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='525.19' width='8.82' height='0.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='209.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='247.79' width='8.82' height='16.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='250.76' width='8.82' height='13.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='253.33' width='8.82' height='11.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='259.58' width='8.82' height='4.75' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='263.34' width='8.82' height='0.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='264.33' width='8.82' height='1.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='264.33' width='8.82' height='2.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='264.33' width='8.82' height='1.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='264.33' width='8.82' height='1.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='264.33' width='8.82' height='0.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='264.33' width='8.82' height='0.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='263.86' width='8.82' height='0.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='264.33' width='8.82' height='4.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='264.33' width='8.82' height='3.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='264.33' width='8.82' height='4.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='264.33' width='8.82' height='2.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='264.33' width='8.82' height='2.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='260.83' width='8.82' height='3.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='260.32' width='8.82' height='4.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='258.63' width='8.82' height='5.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='264.33' width='8.82' height='1.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='259.04' width='8.82' height='5.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='264.24' width='8.82' height='0.090' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='264.06' width='8.82' height='0.27' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='263.21' width='8.82' height='1.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='261.84' width='8.82' height='2.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='264.33' width='8.82' height='0.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='261.53' width='8.82' height='2.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='262.20' width='8.82' height='2.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='262.89' width='8.82' height='1.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='209.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='247.79' width='8.82' height='16.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='250.76' width='8.82' height='13.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='253.33' width='8.82' height='11.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='259.58' width='8.82' height='4.75' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='263.34' width='8.82' height='0.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='264.33' width='8.82' height='1.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='264.33' width='8.82' height='2.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='264.33' width='8.82' height='1.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='264.33' width='8.82' height='1.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='264.33' width='8.82' height='0.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='264.33' width='8.82' height='0.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='263.86' width='8.82' height='0.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='264.33' width='8.82' height='4.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='264.33' width='8.82' height='3.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='264.33' width='8.82' height='4.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='264.33' width='8.82' height='2.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='264.33' width='8.82' height='2.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='260.83' width='8.82' height='3.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='260.32' width='8.82' height='4.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='258.63' width='8.82' height='5.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='264.33' width='8.82' height='1.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='259.04' width='8.82' height='5.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='264.24' width='8.82' height='0.090' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='264.06' width='8.82' height='0.27' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='263.21' width='8.82' height='1.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='261.84' width='8.82' height='2.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='264.33' width='8.82' height='0.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='261.53' width='8.82' height='2.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='262.20' width='8.82' height='2.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='262.89' width='8.82' height='1.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='209.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='515.40' width='8.82' height='9.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='512.76' width='8.82' height='12.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='519.05' width='8.82' height='6.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='523.27' width='8.82' height='1.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='524.05' width='8.82' height='1.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='520.09' width='8.82' height='5.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='523.19' width='8.82' height='1.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='525.19' width='8.82' height='0.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='525.19' width='8.82' height='5.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='525.19' width='8.82' height='0.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='525.19' width='8.82' height='1.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='525.19' width='8.82' height='2.21' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='525.19' width='8.82' height='4.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='522.48' width='8.82' height='2.71' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='525.19' width='8.82' height='3.55' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='524.06' width='8.82' height='1.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='525.19' width='8.82' height='4.68' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='525.19' width='8.82' height='7.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='522.23' width='8.82' height='2.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='520.61' width='8.82' height='4.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='525.19' width='8.82' height='1.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='523.11' width='8.82' height='2.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='525.19' width='8.82' height='0.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='525.19' width='8.82' height='1.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='522.31' width='8.82' height='2.87' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='525.19' width='8.82' height='0.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='525.19' width='8.82' height='0.55' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='525.19' width='8.82' height='5.18' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='525.19' width='8.82' height='2.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='524.50' width='8.82' height='0.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='209.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='515.40' width='8.82' height='9.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='512.76' width='8.82' height='12.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='519.05' width='8.82' height='6.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='523.27' width='8.82' height='1.92' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='524.05' width='8.82' height='1.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='520.09' width='8.82' height='5.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='523.19' width='8.82' height='1.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='525.19' width='8.82' height='0.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='525.19' width='8.82' height='5.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='525.19' width='8.82' height='0.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='525.19' width='8.82' height='1.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='525.19' width='8.82' height='2.21' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='525.19' width='8.82' height='4.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='522.48' width='8.82' height='2.71' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='525.19' width='8.82' height='3.55' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='524.06' width='8.82' height='1.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='525.19' width='8.82' height='4.68' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='525.19' width='8.82' height='7.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='522.23' width='8.82' height='2.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='520.61' width='8.82' height='4.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='525.19' width='8.82' height='1.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='523.11' width='8.82' height='2.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='525.19' width='8.82' height='0.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='525.19' width='8.82' height='1.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='522.31' width='8.82' height='2.87' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='525.19' width='8.82' height='0.45' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='525.19' width='8.82' height='0.55' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='525.19' width='8.82' height='5.18' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='525.19' width='8.82' height='2.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='524.50' width='8.82' height='0.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-1.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-1.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='208.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='194.89' width='8.82' height='68.21' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='228.51' width='8.82' height='34.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='243.14' width='8.82' height='19.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='253.08' width='8.82' height='10.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='255.20' width='8.82' height='7.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='257.20' width='8.82' height='5.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='256.17' width='8.82' height='6.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='259.31' width='8.82' height='3.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='263.09' width='8.82' height='1.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='263.09' width='8.82' height='4.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='263.09' width='8.82' height='2.75' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='263.09' width='8.82' height='2.18' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='263.09' width='8.82' height='1.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='262.46' width='8.82' height='0.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='260.96' width='8.82' height='2.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='261.19' width='8.82' height='1.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='252.93' width='8.82' height='10.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='262.08' width='8.82' height='1.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='263.09' width='8.82' height='0.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='263.09' width='8.82' height='2.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='263.09' width='8.82' height='0.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='261.98' width='8.82' height='1.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='263.09' width='8.82' height='1.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='262.20' width='8.82' height='0.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='263.09' width='8.82' height='0.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='263.09' width='8.82' height='4.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='263.09' width='8.82' height='2.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='263.09' width='8.82' height='3.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='263.09' width='8.82' height='0.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='262.95' width='8.82' height='0.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='208.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='194.89' width='8.82' height='68.21' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='228.51' width='8.82' height='34.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='243.14' width='8.82' height='19.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='253.08' width='8.82' height='10.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='255.20' width='8.82' height='7.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='257.20' width='8.82' height='5.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='256.17' width='8.82' height='6.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='259.31' width='8.82' height='3.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='263.09' width='8.82' height='1.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='263.09' width='8.82' height='4.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='263.09' width='8.82' height='2.75' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='263.09' width='8.82' height='2.18' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='263.09' width='8.82' height='1.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='262.46' width='8.82' height='0.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='260.96' width='8.82' height='2.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='261.19' width='8.82' height='1.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='252.93' width='8.82' height='10.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='262.08' width='8.82' height='1.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='263.09' width='8.82' height='0.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='263.09' width='8.82' height='2.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='263.09' width='8.82' height='0.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='261.98' width='8.82' height='1.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='263.09' width='8.82' height='1.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='262.20' width='8.82' height='0.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='263.09' width='8.82' height='0.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='263.09' width='8.82' height='4.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='263.09' width='8.82' height='2.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='263.09' width='8.82' height='3.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='263.09' width='8.82' height='0.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='262.95' width='8.82' height='0.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='208.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='454.59' width='8.82' height='69.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='495.98' width='8.82' height='27.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='514.97' width='8.82' height='8.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='516.26' width='8.82' height='7.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='522.32' width='8.82' height='1.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='523.95' width='8.82' height='2.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='523.95' width='8.82' height='4.03' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='523.95' width='8.82' height='4.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='523.95' width='8.82' height='2.76' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='523.95' width='8.82' height='3.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='523.95' width='8.82' height='3.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='523.95' width='8.82' height='4.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='523.95' width='8.82' height='6.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='523.95' width='8.82' height='5.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='523.95' width='8.82' height='2.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='523.95' width='8.82' height='2.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='523.95' width='8.82' height='4.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='523.95' width='8.82' height='6.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='523.95' width='8.82' height='4.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='523.95' width='8.82' height='2.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='521.16' width='8.82' height='2.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='522.43' width='8.82' height='1.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='523.30' width='8.82' height='0.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='522.49' width='8.82' height='1.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='522.62' width='8.82' height='1.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='523.95' width='8.82' height='1.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='523.65' width='8.82' height='0.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='523.94' width='8.82' height='0.017' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='523.95' width='8.82' height='0.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='521.77' width='8.82' height='2.18' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='208.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='454.59' width='8.82' height='69.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='495.98' width='8.82' height='27.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='514.97' width='8.82' height='8.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='516.26' width='8.82' height='7.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='522.32' width='8.82' height='1.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='523.95' width='8.82' height='2.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='523.95' width='8.82' height='4.03' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='523.95' width='8.82' height='4.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='523.95' width='8.82' height='2.76' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='523.95' width='8.82' height='3.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='523.95' width='8.82' height='3.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='523.95' width='8.82' height='4.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='523.95' width='8.82' height='6.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='523.95' width='8.82' height='5.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='523.95' width='8.82' height='2.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='523.95' width='8.82' height='2.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='523.95' width='8.82' height='4.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='523.95' width='8.82' height='6.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='523.95' width='8.82' height='4.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='523.95' width='8.82' height='2.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='521.16' width='8.82' height='2.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='522.43' width='8.82' height='1.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='523.30' width='8.82' height='0.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='522.49' width='8.82' height='1.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='522.62' width='8.82' height='1.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='523.95' width='8.82' height='1.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='523.65' width='8.82' height='0.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='523.94' width='8.82' height='0.017' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='523.95' width='8.82' height='0.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='521.77' width='8.82' height='2.18' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='208.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='190.07' width='8.82' height='73.03' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='224.13' width='8.82' height='38.97' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='240.96' width='8.82' height='22.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='249.81' width='8.82' height='13.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='258.35' width='8.82' height='4.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='263.09' width='8.82' height='0.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='263.09' width='8.82' height='0.065' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='263.09' width='8.82' height='0.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='263.09' width='8.82' height='1.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='262.79' width='8.82' height='0.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='262.67' width='8.82' height='0.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='259.21' width='8.82' height='3.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='257.37' width='8.82' height='5.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='258.10' width='8.82' height='4.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='261.52' width='8.82' height='1.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='261.74' width='8.82' height='1.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='260.86' width='8.82' height='2.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='262.38' width='8.82' height='0.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='263.09' width='8.82' height='3.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='263.09' width='8.82' height='2.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='263.09' width='8.82' height='0.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='261.97' width='8.82' height='1.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='262.41' width='8.82' height='0.68' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='263.09' width='8.82' height='0.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='263.09' width='8.82' height='1.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='263.09' width='8.82' height='0.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='258.77' width='8.82' height='4.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='256.14' width='8.82' height='6.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='262.67' width='8.82' height='0.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='261.31' width='8.82' height='1.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='208.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='190.07' width='8.82' height='73.03' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='224.13' width='8.82' height='38.97' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='240.96' width='8.82' height='22.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='249.81' width='8.82' height='13.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='258.35' width='8.82' height='4.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='263.09' width='8.82' height='0.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='263.09' width='8.82' height='0.065' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='263.09' width='8.82' height='0.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='263.09' width='8.82' height='1.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='262.79' width='8.82' height='0.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='262.67' width='8.82' height='0.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='259.21' width='8.82' height='3.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='257.37' width='8.82' height='5.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='258.10' width='8.82' height='4.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='261.52' width='8.82' height='1.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='261.74' width='8.82' height='1.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='260.86' width='8.82' height='2.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='262.38' width='8.82' height='0.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='263.09' width='8.82' height='3.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='263.09' width='8.82' height='2.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='263.09' width='8.82' height='0.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='261.97' width='8.82' height='1.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='262.41' width='8.82' height='0.68' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='263.09' width='8.82' height='0.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='263.09' width='8.82' height='1.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='263.09' width='8.82' height='0.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='258.77' width='8.82' height='4.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='256.14' width='8.82' height='6.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='262.67' width='8.82' height='0.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='261.31' width='8.82' height='1.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='208.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='449.63' width='8.82' height='74.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='492.59' width='8.82' height='31.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='506.05' width='8.82' height='17.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='516.97' width='8.82' height='6.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='519.27' width='8.82' height='4.68' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='520.93' width='8.82' height='3.03' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='523.95' width='8.82' height='2.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='523.95' width='8.82' height='1.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='523.95' width='8.82' height='3.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='523.95' width='8.82' height='5.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='523.95' width='8.82' height='4.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='523.95' width='8.82' height='4.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='523.95' width='8.82' height='8.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='523.95' width='8.82' height='6.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='523.95' width='8.82' height='2.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='523.95' width='8.82' height='1.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='523.07' width='8.82' height='0.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='523.95' width='8.82' height='1.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='522.83' width='8.82' height='1.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='523.95' width='8.82' height='0.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='522.68' width='8.82' height='1.27' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='520.94' width='8.82' height='3.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='522.90' width='8.82' height='1.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='522.63' width='8.82' height='1.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='523.95' width='8.82' height='1.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='523.95' width='8.82' height='2.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='523.95' width='8.82' height='1.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='523.93' width='8.82' height='0.026' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='522.70' width='8.82' height='1.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='523.95' width='8.82' height='2.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='208.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='449.63' width='8.82' height='74.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='492.59' width='8.82' height='31.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='506.05' width='8.82' height='17.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='516.97' width='8.82' height='6.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='519.27' width='8.82' height='4.68' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='520.93' width='8.82' height='3.03' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='523.95' width='8.82' height='2.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='523.95' width='8.82' height='1.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='523.95' width='8.82' height='3.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='523.95' width='8.82' height='5.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='523.95' width='8.82' height='4.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='523.95' width='8.82' height='4.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='523.95' width='8.82' height='8.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='523.95' width='8.82' height='6.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='523.95' width='8.82' height='2.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='523.95' width='8.82' height='1.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='523.07' width='8.82' height='0.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='523.95' width='8.82' height='1.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='522.83' width='8.82' height='1.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='523.95' width='8.82' height='0.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='522.68' width='8.82' height='1.27' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='520.94' width='8.82' height='3.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='522.90' width='8.82' height='1.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='522.63' width='8.82' height='1.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='523.95' width='8.82' height='1.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='523.95' width='8.82' height='2.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='523.95' width='8.82' height='1.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='523.93' width='8.82' height='0.026' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='522.70' width='8.82' height='1.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='523.95' width='8.82' height='2.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-2.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-2.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='210.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='91.51' width='8.82' height='173.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='122.63' width='8.82' height='142.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='142.63' width='8.82' height='122.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='149.76' width='8.82' height='115.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='156.68' width='8.82' height='108.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='173.39' width='8.82' height='91.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='194.44' width='8.82' height='70.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='214.35' width='8.82' height='50.85' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='226.94' width='8.82' height='38.27' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='237.20' width='8.82' height='28.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='242.46' width='8.82' height='22.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='248.10' width='8.82' height='17.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='255.15' width='8.82' height='10.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='260.27' width='8.82' height='4.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='264.40' width='8.82' height='0.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='264.97' width='8.82' height='0.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='265.20' width='8.82' height='0.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='265.20' width='8.82' height='1.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='265.20' width='8.82' height='2.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='265.20' width='8.82' height='3.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='265.20' width='8.82' height='4.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='265.20' width='8.82' height='4.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='265.20' width='8.82' height='4.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='265.20' width='8.82' height='4.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='265.20' width='8.82' height='4.76' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='265.20' width='8.82' height='3.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='265.20' width='8.82' height='3.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='265.20' width='8.82' height='3.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='265.20' width='8.82' height='3.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='265.20' width='8.82' height='3.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='210.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='91.51' width='8.82' height='173.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='122.63' width='8.82' height='142.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='142.63' width='8.82' height='122.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='149.76' width='8.82' height='115.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='156.68' width='8.82' height='108.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='173.39' width='8.82' height='91.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='194.44' width='8.82' height='70.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='214.35' width='8.82' height='50.85' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='226.94' width='8.82' height='38.27' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='237.20' width='8.82' height='28.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='242.46' width='8.82' height='22.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='248.10' width='8.82' height='17.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='255.15' width='8.82' height='10.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='260.27' width='8.82' height='4.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='264.40' width='8.82' height='0.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='264.97' width='8.82' height='0.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='265.20' width='8.82' height='0.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='265.20' width='8.82' height='1.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='265.20' width='8.82' height='2.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='265.20' width='8.82' height='3.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='265.20' width='8.82' height='4.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='265.20' width='8.82' height='4.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='265.20' width='8.82' height='4.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='265.20' width='8.82' height='4.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='265.20' width='8.82' height='4.76' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='265.20' width='8.82' height='3.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='265.20' width='8.82' height='3.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='265.20' width='8.82' height='3.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='265.20' width='8.82' height='3.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='265.20' width='8.82' height='3.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='210.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='392.20' width='8.82' height='133.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='432.85' width='8.82' height='93.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='464.25' width='8.82' height='61.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='479.01' width='8.82' height='47.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='491.02' width='8.82' height='35.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='505.31' width='8.82' height='20.75' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='516.85' width='8.82' height='9.21' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='523.08' width='8.82' height='2.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='526.06' width='8.82' height='1.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='526.06' width='8.82' height='1.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='526.06' width='8.82' height='2.68' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='526.06' width='8.82' height='1.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='526.06' width='8.82' height='1.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='526.06' width='8.82' height='0.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='526.06' width='8.82' height='2.27' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='526.06' width='8.82' height='3.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='526.06' width='8.82' height='3.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='526.06' width='8.82' height='0.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='525.06' width='8.82' height='1.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='525.94' width='8.82' height='0.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='526.06' width='8.82' height='0.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='526.06' width='8.82' height='1.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='526.06' width='8.82' height='2.84' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='526.06' width='8.82' height='3.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='526.06' width='8.82' height='4.03' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='526.06' width='8.82' height='4.09' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='526.06' width='8.82' height='6.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='526.06' width='8.82' height='6.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='526.06' width='8.82' height='3.76' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='526.06' width='8.82' height='1.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='210.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='392.20' width='8.82' height='133.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='432.85' width='8.82' height='93.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='464.25' width='8.82' height='61.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='479.01' width='8.82' height='47.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='491.02' width='8.82' height='35.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='505.31' width='8.82' height='20.75' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='516.85' width='8.82' height='9.21' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='523.08' width='8.82' height='2.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='526.06' width='8.82' height='1.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='526.06' width='8.82' height='1.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='526.06' width='8.82' height='2.68' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='526.06' width='8.82' height='1.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='526.06' width='8.82' height='1.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='526.06' width='8.82' height='0.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='526.06' width='8.82' height='2.27' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='526.06' width='8.82' height='3.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='526.06' width='8.82' height='3.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='526.06' width='8.82' height='0.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='525.06' width='8.82' height='1.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='525.94' width='8.82' height='0.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='526.06' width='8.82' height='0.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='526.06' width='8.82' height='1.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='526.06' width='8.82' height='2.84' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='526.06' width='8.82' height='3.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='526.06' width='8.82' height='4.03' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='526.06' width='8.82' height='4.09' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='526.06' width='8.82' height='6.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='526.06' width='8.82' height='6.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='526.06' width='8.82' height='3.76' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='526.06' width='8.82' height='1.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='210.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='152.27' width='8.82' height='112.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='179.59' width='8.82' height='85.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='195.19' width='8.82' height='70.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='216.64' width='8.82' height='48.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='230.47' width='8.82' height='34.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='241.39' width='8.82' height='23.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='248.46' width='8.82' height='16.75' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='248.97' width='8.82' height='16.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='247.86' width='8.82' height='17.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='245.43' width='8.82' height='19.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='239.08' width='8.82' height='26.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='241.54' width='8.82' height='23.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='238.67' width='8.82' height='26.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='231.95' width='8.82' height='33.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='238.19' width='8.82' height='27.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='240.84' width='8.82' height='24.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='249.21' width='8.82' height='15.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='247.27' width='8.82' height='17.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='235.94' width='8.82' height='29.27' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='244.79' width='8.82' height='20.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='243.49' width='8.82' height='21.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='241.51' width='8.82' height='23.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='235.84' width='8.82' height='29.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='224.71' width='8.82' height='40.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='248.95' width='8.82' height='16.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='250.51' width='8.82' height='14.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='249.62' width='8.82' height='15.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='252.23' width='8.82' height='12.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='254.84' width='8.82' height='10.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='258.61' width='8.82' height='6.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='210.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='152.27' width='8.82' height='112.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='179.59' width='8.82' height='85.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='195.19' width='8.82' height='70.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='216.64' width='8.82' height='48.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='230.47' width='8.82' height='34.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='241.39' width='8.82' height='23.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='248.46' width='8.82' height='16.75' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='248.97' width='8.82' height='16.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='247.86' width='8.82' height='17.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='245.43' width='8.82' height='19.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='239.08' width='8.82' height='26.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='241.54' width='8.82' height='23.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='238.67' width='8.82' height='26.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='231.95' width='8.82' height='33.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='238.19' width='8.82' height='27.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='240.84' width='8.82' height='24.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='249.21' width='8.82' height='15.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='247.27' width='8.82' height='17.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='235.94' width='8.82' height='29.27' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='244.79' width='8.82' height='20.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='243.49' width='8.82' height='21.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='241.51' width='8.82' height='23.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='235.84' width='8.82' height='29.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='224.71' width='8.82' height='40.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='248.95' width='8.82' height='16.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='250.51' width='8.82' height='14.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='249.62' width='8.82' height='15.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='252.23' width='8.82' height='12.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='254.84' width='8.82' height='10.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='258.61' width='8.82' height='6.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='210.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='394.74' width='8.82' height='131.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='429.01' width='8.82' height='97.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='478.95' width='8.82' height='47.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='493.55' width='8.82' height='32.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='507.27' width='8.82' height='18.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='511.80' width='8.82' height='14.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='516.42' width='8.82' height='9.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='520.25' width='8.82' height='5.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='521.67' width='8.82' height='4.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='524.07' width='8.82' height='1.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='525.07' width='8.82' height='1.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='524.63' width='8.82' height='1.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='523.77' width='8.82' height='2.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='523.47' width='8.82' height='2.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='525.72' width='8.82' height='0.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='524.98' width='8.82' height='1.09' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='523.44' width='8.82' height='2.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='522.23' width='8.82' height='3.84' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='521.68' width='8.82' height='4.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='521.67' width='8.82' height='4.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='521.53' width='8.82' height='4.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='523.08' width='8.82' height='2.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='524.82' width='8.82' height='1.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='526.06' width='8.82' height='1.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='526.06' width='8.82' height='2.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='526.06' width='8.82' height='4.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='526.06' width='8.82' height='4.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='526.06' width='8.82' height='3.09' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='526.06' width='8.82' height='1.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='526.06' width='8.82' height='0.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='210.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='394.74' width='8.82' height='131.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='429.01' width='8.82' height='97.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='478.95' width='8.82' height='47.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='493.55' width='8.82' height='32.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='507.27' width='8.82' height='18.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='511.80' width='8.82' height='14.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='516.42' width='8.82' height='9.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='520.25' width='8.82' height='5.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='521.67' width='8.82' height='4.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='524.07' width='8.82' height='1.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='525.07' width='8.82' height='1.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='524.63' width='8.82' height='1.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='523.77' width='8.82' height='2.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='523.47' width='8.82' height='2.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='525.72' width='8.82' height='0.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='524.98' width='8.82' height='1.09' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='523.44' width='8.82' height='2.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='522.23' width='8.82' height='3.84' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='521.68' width='8.82' height='4.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='521.67' width='8.82' height='4.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='521.53' width='8.82' height='4.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='523.08' width='8.82' height='2.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='524.82' width='8.82' height='1.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='526.06' width='8.82' height='1.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='526.06' width='8.82' height='2.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='526.06' width='8.82' height='4.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='526.06' width='8.82' height='4.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='526.06' width='8.82' height='3.09' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='526.06' width='8.82' height='1.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='526.06' width='8.82' height='0.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-3.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-3.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='211.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='213.19' width='8.82' height='52.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='243.51' width='8.82' height='22.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='258.47' width='8.82' height='7.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='260.98' width='8.82' height='5.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='265.17' width='8.82' height='0.97' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='266.14' width='8.82' height='5.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='266.14' width='8.82' height='3.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='263.19' width='8.82' height='2.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='266.14' width='8.82' height='0.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='262.26' width='8.82' height='3.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='260.83' width='8.82' height='5.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='264.14' width='8.82' height='2.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='266.10' width='8.82' height='0.041' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='263.52' width='8.82' height='2.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='263.31' width='8.82' height='2.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='259.97' width='8.82' height='6.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='266.14' width='8.82' height='0.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='266.14' width='8.82' height='0.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='265.09' width='8.82' height='1.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='266.14' width='8.82' height='2.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='262.49' width='8.82' height='3.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='266.14' width='8.82' height='0.045' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='261.66' width='8.82' height='4.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='264.66' width='8.82' height='1.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='266.10' width='8.82' height='0.044' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='263.67' width='8.82' height='2.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='266.14' width='8.82' height='1.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='266.14' width='8.82' height='2.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='266.14' width='8.82' height='4.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='266.14' width='8.82' height='0.065' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='211.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='213.19' width='8.82' height='52.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='243.51' width='8.82' height='22.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='258.47' width='8.82' height='7.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='260.98' width='8.82' height='5.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='265.17' width='8.82' height='0.97' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='266.14' width='8.82' height='5.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='266.14' width='8.82' height='3.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='263.19' width='8.82' height='2.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='266.14' width='8.82' height='0.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='262.26' width='8.82' height='3.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='260.83' width='8.82' height='5.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='264.14' width='8.82' height='2.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='266.10' width='8.82' height='0.041' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='263.52' width='8.82' height='2.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='263.31' width='8.82' height='2.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='259.97' width='8.82' height='6.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='266.14' width='8.82' height='0.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='266.14' width='8.82' height='0.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='265.09' width='8.82' height='1.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='266.14' width='8.82' height='2.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='262.49' width='8.82' height='3.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='266.14' width='8.82' height='0.045' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='261.66' width='8.82' height='4.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='264.66' width='8.82' height='1.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='266.10' width='8.82' height='0.044' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='263.67' width='8.82' height='2.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='266.14' width='8.82' height='1.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='266.14' width='8.82' height='2.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='266.14' width='8.82' height='4.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='266.14' width='8.82' height='0.065' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='211.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='472.20' width='8.82' height='54.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='501.75' width='8.82' height='25.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='514.09' width='8.82' height='12.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='521.18' width='8.82' height='5.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='517.85' width='8.82' height='9.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='524.43' width='8.82' height='2.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='523.60' width='8.82' height='3.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='523.42' width='8.82' height='3.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='522.35' width='8.82' height='4.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='522.26' width='8.82' height='4.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='518.95' width='8.82' height='8.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='519.67' width='8.82' height='7.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='517.11' width='8.82' height='9.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='519.05' width='8.82' height='7.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='526.56' width='8.82' height='0.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='524.79' width='8.82' height='2.21' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='527.00' width='8.82' height='0.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='524.62' width='8.82' height='2.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='524.60' width='8.82' height='2.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='527.00' width='8.82' height='0.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='527.00' width='8.82' height='0.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='521.67' width='8.82' height='5.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='522.35' width='8.82' height='4.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='527.00' width='8.82' height='1.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='526.39' width='8.82' height='0.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='525.86' width='8.82' height='1.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='526.26' width='8.82' height='0.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='523.68' width='8.82' height='3.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='527.00' width='8.82' height='2.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='527.00' width='8.82' height='0.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='211.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='472.20' width='8.82' height='54.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='501.75' width='8.82' height='25.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='514.09' width='8.82' height='12.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='521.18' width='8.82' height='5.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='517.85' width='8.82' height='9.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='524.43' width='8.82' height='2.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='523.60' width='8.82' height='3.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='523.42' width='8.82' height='3.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='522.35' width='8.82' height='4.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='522.26' width='8.82' height='4.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='518.95' width='8.82' height='8.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='519.67' width='8.82' height='7.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='517.11' width='8.82' height='9.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='519.05' width='8.82' height='7.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='526.56' width='8.82' height='0.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='524.79' width='8.82' height='2.21' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='527.00' width='8.82' height='0.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='524.62' width='8.82' height='2.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='524.60' width='8.82' height='2.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='527.00' width='8.82' height='0.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='527.00' width='8.82' height='0.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='521.67' width='8.82' height='5.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='522.35' width='8.82' height='4.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='527.00' width='8.82' height='1.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='526.39' width='8.82' height='0.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='525.86' width='8.82' height='1.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='526.26' width='8.82' height='0.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='523.68' width='8.82' height='3.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='527.00' width='8.82' height='2.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='527.00' width='8.82' height='0.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='211.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='214.23' width='8.82' height='51.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='247.03' width='8.82' height='19.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='259.70' width='8.82' height='6.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='262.26' width='8.82' height='3.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='264.80' width='8.82' height='1.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='265.71' width='8.82' height='0.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='266.14' width='8.82' height='1.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='262.57' width='8.82' height='3.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='265.62' width='8.82' height='0.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='265.32' width='8.82' height='0.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='266.02' width='8.82' height='0.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='266.14' width='8.82' height='1.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='266.14' width='8.82' height='2.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='266.14' width='8.82' height='2.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='266.14' width='8.82' height='1.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='263.06' width='8.82' height='3.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='264.97' width='8.82' height='1.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='266.14' width='8.82' height='2.76' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='266.14' width='8.82' height='4.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='266.14' width='8.82' height='0.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='264.53' width='8.82' height='1.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='266.14' width='8.82' height='1.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='266.14' width='8.82' height='3.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='266.14' width='8.82' height='0.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='266.14' width='8.82' height='0.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='263.19' width='8.82' height='2.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='266.12' width='8.82' height='0.024' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='264.17' width='8.82' height='1.97' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='263.07' width='8.82' height='3.07' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='264.15' width='8.82' height='1.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='211.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='214.23' width='8.82' height='51.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='247.03' width='8.82' height='19.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='259.70' width='8.82' height='6.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='262.26' width='8.82' height='3.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='264.80' width='8.82' height='1.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='265.71' width='8.82' height='0.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='266.14' width='8.82' height='1.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='262.57' width='8.82' height='3.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='265.62' width='8.82' height='0.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='265.32' width='8.82' height='0.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='266.02' width='8.82' height='0.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='266.14' width='8.82' height='1.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='266.14' width='8.82' height='2.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='266.14' width='8.82' height='2.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='266.14' width='8.82' height='1.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='263.06' width='8.82' height='3.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='264.97' width='8.82' height='1.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='266.14' width='8.82' height='2.76' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='266.14' width='8.82' height='4.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='266.14' width='8.82' height='0.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='264.53' width='8.82' height='1.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='266.14' width='8.82' height='1.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='266.14' width='8.82' height='3.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='266.14' width='8.82' height='0.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='266.14' width='8.82' height='0.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='263.19' width='8.82' height='2.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='266.12' width='8.82' height='0.024' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='264.17' width='8.82' height='1.97' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='263.07' width='8.82' height='3.07' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='264.15' width='8.82' height='1.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='211.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='469.88' width='8.82' height='57.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='503.94' width='8.82' height='23.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='513.69' width='8.82' height='13.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='519.79' width='8.82' height='7.21' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='527.00' width='8.82' height='0.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='527.00' width='8.82' height='2.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='527.00' width='8.82' height='1.73' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='527.00' width='8.82' height='1.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='527.00' width='8.82' height='1.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='526.72' width='8.82' height='0.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='527.00' width='8.82' height='0.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='527.00' width='8.82' height='3.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='527.00' width='8.82' height='1.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='527.00' width='8.82' height='3.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='527.00' width='8.82' height='3.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='527.00' width='8.82' height='0.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='524.89' width='8.82' height='2.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='525.26' width='8.82' height='1.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='527.00' width='8.82' height='1.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='527.00' width='8.82' height='3.27' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='527.00' width='8.82' height='0.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='522.76' width='8.82' height='4.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='521.86' width='8.82' height='5.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='525.94' width='8.82' height='1.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='525.64' width='8.82' height='1.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='527.00' width='8.82' height='0.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='524.52' width='8.82' height='2.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='525.39' width='8.82' height='1.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='527.00' width='8.82' height='1.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='527.00' width='8.82' height='3.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='211.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='469.88' width='8.82' height='57.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='503.94' width='8.82' height='23.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='513.69' width='8.82' height='13.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='519.79' width='8.82' height='7.21' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='527.00' width='8.82' height='0.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='527.00' width='8.82' height='2.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='527.00' width='8.82' height='1.73' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='527.00' width='8.82' height='1.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='527.00' width='8.82' height='1.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='526.72' width='8.82' height='0.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='527.00' width='8.82' height='0.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='527.00' width='8.82' height='3.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='527.00' width='8.82' height='1.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='527.00' width='8.82' height='3.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='527.00' width='8.82' height='3.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='527.00' width='8.82' height='0.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='524.89' width='8.82' height='2.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='525.26' width='8.82' height='1.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='527.00' width='8.82' height='1.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='527.00' width='8.82' height='3.27' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='527.00' width='8.82' height='0.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='522.76' width='8.82' height='4.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='521.86' width='8.82' height='5.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='525.94' width='8.82' height='1.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='525.64' width='8.82' height='1.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='527.00' width='8.82' height='0.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='524.52' width='8.82' height='2.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='525.39' width='8.82' height='1.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='527.00' width='8.82' height='1.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='527.00' width='8.82' height='3.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-4.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-4.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='211.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='137.87' width='8.82' height='128.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='195.64' width='8.82' height='70.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='225.48' width='8.82' height='40.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='240.85' width='8.82' height='25.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='249.31' width='8.82' height='16.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='252.18' width='8.82' height='13.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='250.51' width='8.82' height='15.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='252.66' width='8.82' height='13.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='260.39' width='8.82' height='5.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='263.44' width='8.82' height='2.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='263.63' width='8.82' height='2.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='263.99' width='8.82' height='1.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='265.45' width='8.82' height='0.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='264.33' width='8.82' height='1.55' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='262.29' width='8.82' height='3.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='261.06' width='8.82' height='4.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='260.34' width='8.82' height='5.55' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='259.12' width='8.82' height='6.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='259.75' width='8.82' height='6.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='260.96' width='8.82' height='4.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='262.90' width='8.82' height='2.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='264.81' width='8.82' height='1.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='264.55' width='8.82' height='1.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='261.94' width='8.82' height='3.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='260.86' width='8.82' height='5.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='260.49' width='8.82' height='5.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='258.45' width='8.82' height='7.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='259.36' width='8.82' height='6.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='259.35' width='8.82' height='6.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='261.17' width='8.82' height='4.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='211.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='137.87' width='8.82' height='128.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='195.64' width='8.82' height='70.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='225.48' width='8.82' height='40.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='240.85' width='8.82' height='25.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='249.31' width='8.82' height='16.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='252.18' width='8.82' height='13.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='250.51' width='8.82' height='15.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='252.66' width='8.82' height='13.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='260.39' width='8.82' height='5.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='263.44' width='8.82' height='2.45' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='263.63' width='8.82' height='2.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='263.99' width='8.82' height='1.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='265.45' width='8.82' height='0.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='264.33' width='8.82' height='1.55' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='262.29' width='8.82' height='3.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='261.06' width='8.82' height='4.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='260.34' width='8.82' height='5.55' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='259.12' width='8.82' height='6.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='259.75' width='8.82' height='6.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='260.96' width='8.82' height='4.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='262.90' width='8.82' height='2.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='264.81' width='8.82' height='1.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='264.55' width='8.82' height='1.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='261.94' width='8.82' height='3.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='260.86' width='8.82' height='5.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='260.49' width='8.82' height='5.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='258.45' width='8.82' height='7.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='259.36' width='8.82' height='6.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='259.35' width='8.82' height='6.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='261.17' width='8.82' height='4.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='211.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='424.76' width='8.82' height='101.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='459.67' width='8.82' height='67.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='482.09' width='8.82' height='44.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='496.48' width='8.82' height='30.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='504.87' width='8.82' height='21.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='509.30' width='8.82' height='17.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='511.12' width='8.82' height='15.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='507.61' width='8.82' height='19.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='514.83' width='8.82' height='11.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='515.71' width='8.82' height='11.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='519.69' width='8.82' height='7.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='523.15' width='8.82' height='3.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='524.48' width='8.82' height='2.27' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='525.52' width='8.82' height='1.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='526.74' width='8.82' height='1.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='526.74' width='8.82' height='2.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='526.74' width='8.82' height='4.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='526.74' width='8.82' height='3.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='526.74' width='8.82' height='4.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='526.74' width='8.82' height='4.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='526.74' width='8.82' height='2.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='526.74' width='8.82' height='2.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='526.74' width='8.82' height='3.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='526.74' width='8.82' height='4.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='526.74' width='8.82' height='5.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='526.74' width='8.82' height='3.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='526.74' width='8.82' height='2.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='526.74' width='8.82' height='1.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='526.74' width='8.82' height='0.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='526.74' width='8.82' height='2.07' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='211.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='424.76' width='8.82' height='101.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='459.67' width='8.82' height='67.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='482.09' width='8.82' height='44.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='496.48' width='8.82' height='30.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='504.87' width='8.82' height='21.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='509.30' width='8.82' height='17.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='511.12' width='8.82' height='15.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='507.61' width='8.82' height='19.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='514.83' width='8.82' height='11.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='515.71' width='8.82' height='11.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='519.69' width='8.82' height='7.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='523.15' width='8.82' height='3.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='524.48' width='8.82' height='2.27' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='525.52' width='8.82' height='1.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='526.74' width='8.82' height='1.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='526.74' width='8.82' height='2.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='526.74' width='8.82' height='4.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='526.74' width='8.82' height='3.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='526.74' width='8.82' height='4.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='526.74' width='8.82' height='4.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='526.74' width='8.82' height='2.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='526.74' width='8.82' height='2.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='526.74' width='8.82' height='3.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='526.74' width='8.82' height='4.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='526.74' width='8.82' height='5.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='526.74' width='8.82' height='3.92' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='526.74' width='8.82' height='2.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='526.74' width='8.82' height='1.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='526.74' width='8.82' height='0.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='526.74' width='8.82' height='2.07' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='211.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='142.11' width='8.82' height='123.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='180.54' width='8.82' height='85.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='207.73' width='8.82' height='58.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='226.52' width='8.82' height='39.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='236.31' width='8.82' height='29.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='249.89' width='8.82' height='15.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='259.18' width='8.82' height='6.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='263.54' width='8.82' height='2.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='265.70' width='8.82' height='0.18' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='265.83' width='8.82' height='0.053' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='265.89' width='8.82' height='1.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='265.89' width='8.82' height='3.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='265.89' width='8.82' height='5.73' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='265.89' width='8.82' height='5.71' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='265.89' width='8.82' height='5.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='265.89' width='8.82' height='0.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='264.78' width='8.82' height='1.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='265.89' width='8.82' height='2.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='265.89' width='8.82' height='1.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='264.94' width='8.82' height='0.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='265.89' width='8.82' height='0.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='265.89' width='8.82' height='2.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='265.89' width='8.82' height='3.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='265.89' width='8.82' height='1.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='263.81' width='8.82' height='2.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='262.78' width='8.82' height='3.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='263.55' width='8.82' height='2.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='262.56' width='8.82' height='3.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='262.04' width='8.82' height='3.84' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='258.89' width='8.82' height='6.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='211.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='142.11' width='8.82' height='123.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='180.54' width='8.82' height='85.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='207.73' width='8.82' height='58.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='226.52' width='8.82' height='39.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='236.31' width='8.82' height='29.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='249.89' width='8.82' height='15.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='259.18' width='8.82' height='6.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='263.54' width='8.82' height='2.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='265.70' width='8.82' height='0.18' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='265.83' width='8.82' height='0.053' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='265.89' width='8.82' height='1.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='265.89' width='8.82' height='3.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='265.89' width='8.82' height='5.73' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='265.89' width='8.82' height='5.71' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='265.89' width='8.82' height='5.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='265.89' width='8.82' height='0.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='264.78' width='8.82' height='1.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='265.89' width='8.82' height='2.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='265.89' width='8.82' height='1.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='264.94' width='8.82' height='0.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='265.89' width='8.82' height='0.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='265.89' width='8.82' height='2.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='265.89' width='8.82' height='3.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='265.89' width='8.82' height='1.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='263.81' width='8.82' height='2.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='262.78' width='8.82' height='3.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='263.55' width='8.82' height='2.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='262.56' width='8.82' height='3.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='262.04' width='8.82' height='3.84' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='258.89' width='8.82' height='6.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='211.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='406.96' width='8.82' height='119.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='443.52' width='8.82' height='83.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='463.91' width='8.82' height='62.84' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='479.80' width='8.82' height='46.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='496.80' width='8.82' height='29.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='503.20' width='8.82' height='23.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='517.84' width='8.82' height='8.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='521.50' width='8.82' height='5.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='525.23' width='8.82' height='1.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='526.74' width='8.82' height='0.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='526.74' width='8.82' height='1.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='526.74' width='8.82' height='3.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='526.74' width='8.82' height='3.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='526.74' width='8.82' height='4.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='526.74' width='8.82' height='4.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='526.74' width='8.82' height='4.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='526.74' width='8.82' height='1.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='526.74' width='8.82' height='3.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='526.74' width='8.82' height='0.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='525.39' width='8.82' height='1.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='524.82' width='8.82' height='1.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='523.35' width='8.82' height='3.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='517.16' width='8.82' height='9.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='518.84' width='8.82' height='7.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='522.95' width='8.82' height='3.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='520.23' width='8.82' height='6.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='518.74' width='8.82' height='8.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='521.96' width='8.82' height='4.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='524.05' width='8.82' height='2.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='526.74' width='8.82' height='0.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='211.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='406.96' width='8.82' height='119.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='443.52' width='8.82' height='83.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='463.91' width='8.82' height='62.84' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='479.80' width='8.82' height='46.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='496.80' width='8.82' height='29.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='503.20' width='8.82' height='23.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='517.84' width='8.82' height='8.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='521.50' width='8.82' height='5.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='525.23' width='8.82' height='1.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='526.74' width='8.82' height='0.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='526.74' width='8.82' height='1.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='526.74' width='8.82' height='3.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='526.74' width='8.82' height='3.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='526.74' width='8.82' height='4.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='526.74' width='8.82' height='4.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='526.74' width='8.82' height='4.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='526.74' width='8.82' height='1.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='526.74' width='8.82' height='3.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='526.74' width='8.82' height='0.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='525.39' width='8.82' height='1.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='524.82' width='8.82' height='1.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='523.35' width='8.82' height='3.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='517.16' width='8.82' height='9.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='518.84' width='8.82' height='7.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='522.95' width='8.82' height='3.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='520.23' width='8.82' height='6.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='518.74' width='8.82' height='8.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='521.96' width='8.82' height='4.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='524.05' width='8.82' height='2.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='526.74' width='8.82' height='0.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-5.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-5.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='209.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='213.21' width='8.82' height='50.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='243.54' width='8.82' height='20.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='251.98' width='8.82' height='11.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='258.17' width='8.82' height='5.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='263.59' width='8.82' height='0.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='263.59' width='8.82' height='3.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='263.59' width='8.82' height='3.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='263.59' width='8.82' height='0.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='260.78' width='8.82' height='2.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='260.19' width='8.82' height='3.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='260.43' width='8.82' height='3.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='257.25' width='8.82' height='6.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='262.03' width='8.82' height='1.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='263.59' width='8.82' height='1.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='261.57' width='8.82' height='2.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='260.25' width='8.82' height='3.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='263.12' width='8.82' height='0.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='259.79' width='8.82' height='3.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='262.48' width='8.82' height='1.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='261.56' width='8.82' height='2.03' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='261.52' width='8.82' height='2.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='261.40' width='8.82' height='2.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='259.40' width='8.82' height='4.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='263.18' width='8.82' height='0.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='263.59' width='8.82' height='2.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='263.59' width='8.82' height='7.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='263.59' width='8.82' height='8.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='262.15' width='8.82' height='1.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='263.59' width='8.82' height='1.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='263.59' width='8.82' height='0.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='209.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='213.21' width='8.82' height='50.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='243.54' width='8.82' height='20.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='251.98' width='8.82' height='11.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='258.17' width='8.82' height='5.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='263.59' width='8.82' height='0.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='263.59' width='8.82' height='3.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='263.59' width='8.82' height='3.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='263.59' width='8.82' height='0.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='260.78' width='8.82' height='2.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='260.19' width='8.82' height='3.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='260.43' width='8.82' height='3.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='257.25' width='8.82' height='6.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='262.03' width='8.82' height='1.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='263.59' width='8.82' height='1.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='261.57' width='8.82' height='2.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='260.25' width='8.82' height='3.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='263.12' width='8.82' height='0.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='259.79' width='8.82' height='3.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='262.48' width='8.82' height='1.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='261.56' width='8.82' height='2.03' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='261.52' width='8.82' height='2.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='261.40' width='8.82' height='2.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='259.40' width='8.82' height='4.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='263.18' width='8.82' height='0.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='263.59' width='8.82' height='2.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='263.59' width='8.82' height='7.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='263.59' width='8.82' height='8.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='262.15' width='8.82' height='1.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='263.59' width='8.82' height='1.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='263.59' width='8.82' height='0.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='209.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='468.83' width='8.82' height='55.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='503.88' width='8.82' height='20.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='514.05' width='8.82' height='10.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='520.44' width='8.82' height='4.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='521.06' width='8.82' height='3.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='524.45' width='8.82' height='1.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='523.29' width='8.82' height='1.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='524.45' width='8.82' height='2.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='524.13' width='8.82' height='0.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='523.06' width='8.82' height='1.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='524.45' width='8.82' height='1.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='522.46' width='8.82' height='1.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='524.32' width='8.82' height='0.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='524.45' width='8.82' height='4.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='524.45' width='8.82' height='3.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='523.78' width='8.82' height='0.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='524.45' width='8.82' height='1.87' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='523.09' width='8.82' height='1.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='522.27' width='8.82' height='2.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='522.66' width='8.82' height='1.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='523.78' width='8.82' height='0.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='524.45' width='8.82' height='3.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='519.49' width='8.82' height='4.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='520.75' width='8.82' height='3.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='523.30' width='8.82' height='1.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='524.45' width='8.82' height='0.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='523.83' width='8.82' height='0.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='524.45' width='8.82' height='1.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='524.45' width='8.82' height='1.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='522.49' width='8.82' height='1.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='209.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='468.83' width='8.82' height='55.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='503.88' width='8.82' height='20.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='514.05' width='8.82' height='10.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='520.44' width='8.82' height='4.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='521.06' width='8.82' height='3.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='524.45' width='8.82' height='1.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='523.29' width='8.82' height='1.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='524.45' width='8.82' height='2.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='524.13' width='8.82' height='0.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='523.06' width='8.82' height='1.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='524.45' width='8.82' height='1.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='522.46' width='8.82' height='1.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='524.32' width='8.82' height='0.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='524.45' width='8.82' height='4.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='524.45' width='8.82' height='3.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='523.78' width='8.82' height='0.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='524.45' width='8.82' height='1.87' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='523.09' width='8.82' height='1.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='522.27' width='8.82' height='2.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='522.66' width='8.82' height='1.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='523.78' width='8.82' height='0.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='524.45' width='8.82' height='3.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='519.49' width='8.82' height='4.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='520.75' width='8.82' height='3.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='523.30' width='8.82' height='1.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='524.45' width='8.82' height='0.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='523.83' width='8.82' height='0.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='524.45' width='8.82' height='1.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='524.45' width='8.82' height='1.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='522.49' width='8.82' height='1.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='209.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='215.08' width='8.82' height='48.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='243.41' width='8.82' height='20.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='254.10' width='8.82' height='9.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='257.28' width='8.82' height='6.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='262.68' width='8.82' height='0.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='263.59' width='8.82' height='5.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='263.59' width='8.82' height='4.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='263.59' width='8.82' height='3.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='263.59' width='8.82' height='0.085' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='262.70' width='8.82' height='0.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='263.59' width='8.82' height='2.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='263.59' width='8.82' height='3.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='263.59' width='8.82' height='4.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='263.59' width='8.82' height='2.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='259.87' width='8.82' height='3.73' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='252.12' width='8.82' height='11.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='260.29' width='8.82' height='3.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='255.29' width='8.82' height='8.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='263.38' width='8.82' height='0.21' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='257.85' width='8.82' height='5.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='263.59' width='8.82' height='0.049' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='263.15' width='8.82' height='0.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='263.59' width='8.82' height='1.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='261.19' width='8.82' height='2.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='262.15' width='8.82' height='1.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='263.59' width='8.82' height='3.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='263.59' width='8.82' height='3.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='263.59' width='8.82' height='0.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='263.30' width='8.82' height='0.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='263.59' width='8.82' height='1.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='209.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='215.08' width='8.82' height='48.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='243.41' width='8.82' height='20.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='254.10' width='8.82' height='9.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='257.28' width='8.82' height='6.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='262.68' width='8.82' height='0.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='263.59' width='8.82' height='5.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='263.59' width='8.82' height='4.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='263.59' width='8.82' height='3.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='263.59' width='8.82' height='0.085' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='262.70' width='8.82' height='0.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='263.59' width='8.82' height='2.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='263.59' width='8.82' height='3.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='263.59' width='8.82' height='4.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='263.59' width='8.82' height='2.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='259.87' width='8.82' height='3.73' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='252.12' width='8.82' height='11.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='260.29' width='8.82' height='3.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='255.29' width='8.82' height='8.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='263.38' width='8.82' height='0.21' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='257.85' width='8.82' height='5.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='263.59' width='8.82' height='0.049' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='263.15' width='8.82' height='0.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='263.59' width='8.82' height='1.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='261.19' width='8.82' height='2.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='262.15' width='8.82' height='1.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='263.59' width='8.82' height='3.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='263.59' width='8.82' height='3.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='263.59' width='8.82' height='0.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='263.30' width='8.82' height='0.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='263.59' width='8.82' height='1.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='209.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='473.21' width='8.82' height='51.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='501.00' width='8.82' height='23.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='517.47' width='8.82' height='6.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='519.87' width='8.82' height='4.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='522.48' width='8.82' height='1.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='522.67' width='8.82' height='1.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='524.11' width='8.82' height='0.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='524.45' width='8.82' height='1.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='523.95' width='8.82' height='0.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='524.45' width='8.82' height='3.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='524.45' width='8.82' height='1.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='524.45' width='8.82' height='2.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='524.45' width='8.82' height='6.75' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='524.45' width='8.82' height='6.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='523.32' width='8.82' height='1.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='524.45' width='8.82' height='7.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='524.45' width='8.82' height='2.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='524.45' width='8.82' height='0.79' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='524.45' width='8.82' height='0.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='524.45' width='8.82' height='2.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='523.01' width='8.82' height='1.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='524.45' width='8.82' height='3.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='524.45' width='8.82' height='0.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='524.45' width='8.82' height='0.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='517.95' width='8.82' height='6.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='518.39' width='8.82' height='6.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='521.05' width='8.82' height='3.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='524.45' width='8.82' height='1.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='524.45' width='8.82' height='0.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='524.45' width='8.82' height='1.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='209.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='473.21' width='8.82' height='51.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='501.00' width='8.82' height='23.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='517.47' width='8.82' height='6.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='519.87' width='8.82' height='4.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='522.48' width='8.82' height='1.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='522.67' width='8.82' height='1.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='524.11' width='8.82' height='0.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='524.45' width='8.82' height='1.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='523.95' width='8.82' height='0.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='524.45' width='8.82' height='3.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='524.45' width='8.82' height='1.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='524.45' width='8.82' height='2.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='524.45' width='8.82' height='6.75' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='524.45' width='8.82' height='6.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='523.32' width='8.82' height='1.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='524.45' width='8.82' height='7.67' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='524.45' width='8.82' height='2.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='524.45' width='8.82' height='0.79' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='524.45' width='8.82' height='0.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='524.45' width='8.82' height='2.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='523.01' width='8.82' height='1.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='524.45' width='8.82' height='3.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='524.45' width='8.82' height='0.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='524.45' width='8.82' height='0.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='517.95' width='8.82' height='6.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='518.39' width='8.82' height='6.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='521.05' width='8.82' height='3.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='524.45' width='8.82' height='1.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='524.45' width='8.82' height='0.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='524.45' width='8.82' height='1.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-6.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-6.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='209.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='169.49' width='8.82' height='94.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='203.19' width='8.82' height='60.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='223.39' width='8.82' height='40.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='237.64' width='8.82' height='26.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='243.63' width='8.82' height='20.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='252.42' width='8.82' height='11.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='251.86' width='8.82' height='12.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='255.85' width='8.82' height='8.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='257.94' width='8.82' height='6.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='261.03' width='8.82' height='2.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='261.65' width='8.82' height='2.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='262.61' width='8.82' height='1.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='263.99' width='8.82' height='3.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='263.99' width='8.82' height='2.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='263.99' width='8.82' height='6.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='263.99' width='8.82' height='7.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='263.99' width='8.82' height='5.97' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='263.99' width='8.82' height='5.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='263.99' width='8.82' height='4.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='263.99' width='8.82' height='2.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='263.99' width='8.82' height='7.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='263.99' width='8.82' height='7.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='263.99' width='8.82' height='3.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='263.99' width='8.82' height='3.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='263.99' width='8.82' height='6.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='263.99' width='8.82' height='3.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='263.99' width='8.82' height='2.84' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='261.65' width='8.82' height='2.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='262.33' width='8.82' height='1.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='261.75' width='8.82' height='2.24' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='209.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='169.49' width='8.82' height='94.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='203.19' width='8.82' height='60.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='223.39' width='8.82' height='40.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='237.64' width='8.82' height='26.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='243.63' width='8.82' height='20.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='252.42' width='8.82' height='11.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='251.86' width='8.82' height='12.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='255.85' width='8.82' height='8.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='257.94' width='8.82' height='6.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='261.03' width='8.82' height='2.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='261.65' width='8.82' height='2.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='262.61' width='8.82' height='1.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='263.99' width='8.82' height='3.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='263.99' width='8.82' height='2.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='263.99' width='8.82' height='6.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='263.99' width='8.82' height='7.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='263.99' width='8.82' height='5.97' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='263.99' width='8.82' height='5.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='263.99' width='8.82' height='4.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='263.99' width='8.82' height='2.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='263.99' width='8.82' height='7.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='263.99' width='8.82' height='7.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='263.99' width='8.82' height='3.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='263.99' width='8.82' height='3.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='263.99' width='8.82' height='6.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='263.99' width='8.82' height='3.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='263.99' width='8.82' height='2.84' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='261.65' width='8.82' height='2.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='262.33' width='8.82' height='1.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='261.75' width='8.82' height='2.24' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='209.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='423.09' width='8.82' height='101.76' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='461.81' width='8.82' height='63.03' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='488.23' width='8.82' height='36.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='506.41' width='8.82' height='18.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='517.29' width='8.82' height='7.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='521.08' width='8.82' height='3.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='517.84' width='8.82' height='7.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='514.70' width='8.82' height='10.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='515.19' width='8.82' height='9.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='517.38' width='8.82' height='7.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='518.62' width='8.82' height='6.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='522.45' width='8.82' height='2.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='524.50' width='8.82' height='0.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='524.85' width='8.82' height='0.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='524.85' width='8.82' height='6.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='524.85' width='8.82' height='1.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='524.85' width='8.82' height='2.85' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='524.85' width='8.82' height='1.46' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='524.85' width='8.82' height='0.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='521.32' width='8.82' height='3.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='518.88' width='8.82' height='5.97' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='517.44' width='8.82' height='7.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='518.87' width='8.82' height='5.98' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='518.24' width='8.82' height='6.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='521.92' width='8.82' height='2.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='524.85' width='8.82' height='0.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='521.48' width='8.82' height='3.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='520.72' width='8.82' height='4.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='523.93' width='8.82' height='0.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='524.85' width='8.82' height='1.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='209.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='423.09' width='8.82' height='101.76' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='461.81' width='8.82' height='63.03' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='488.23' width='8.82' height='36.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='506.41' width='8.82' height='18.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='517.29' width='8.82' height='7.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='521.08' width='8.82' height='3.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='517.84' width='8.82' height='7.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='514.70' width='8.82' height='10.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='515.19' width='8.82' height='9.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='517.38' width='8.82' height='7.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='518.62' width='8.82' height='6.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='522.45' width='8.82' height='2.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='524.50' width='8.82' height='0.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='524.85' width='8.82' height='0.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='524.85' width='8.82' height='6.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='524.85' width='8.82' height='1.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='524.85' width='8.82' height='2.85' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='524.85' width='8.82' height='1.46' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='524.85' width='8.82' height='0.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='521.32' width='8.82' height='3.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='518.88' width='8.82' height='5.97' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='517.44' width='8.82' height='7.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='518.87' width='8.82' height='5.98' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='518.24' width='8.82' height='6.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='521.92' width='8.82' height='2.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='524.85' width='8.82' height='0.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='521.48' width='8.82' height='3.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='520.72' width='8.82' height='4.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='523.93' width='8.82' height='0.92' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='524.85' width='8.82' height='1.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='209.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='183.43' width='8.82' height='80.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='214.00' width='8.82' height='49.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='230.54' width='8.82' height='33.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='242.00' width='8.82' height='21.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='251.09' width='8.82' height='12.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='257.41' width='8.82' height='6.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='262.52' width='8.82' height='1.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='259.83' width='8.82' height='4.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='259.26' width='8.82' height='4.73' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='260.19' width='8.82' height='3.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='261.67' width='8.82' height='2.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='258.83' width='8.82' height='5.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='259.88' width='8.82' height='4.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='263.52' width='8.82' height='0.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='263.08' width='8.82' height='0.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='263.99' width='8.82' height='2.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='263.99' width='8.82' height='0.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='262.03' width='8.82' height='1.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='263.99' width='8.82' height='0.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='263.99' width='8.82' height='1.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='263.41' width='8.82' height='0.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='261.54' width='8.82' height='2.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='259.19' width='8.82' height='4.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='256.82' width='8.82' height='7.17' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='259.94' width='8.82' height='4.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='263.99' width='8.82' height='0.017' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='261.16' width='8.82' height='2.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='259.94' width='8.82' height='4.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='263.90' width='8.82' height='0.090' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='262.30' width='8.82' height='1.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='209.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='183.43' width='8.82' height='80.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='214.00' width='8.82' height='49.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='230.54' width='8.82' height='33.45' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='242.00' width='8.82' height='21.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='251.09' width='8.82' height='12.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='257.41' width='8.82' height='6.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='262.52' width='8.82' height='1.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='259.83' width='8.82' height='4.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='259.26' width='8.82' height='4.73' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='260.19' width='8.82' height='3.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='261.67' width='8.82' height='2.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='258.83' width='8.82' height='5.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='259.88' width='8.82' height='4.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='263.52' width='8.82' height='0.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='263.08' width='8.82' height='0.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='263.99' width='8.82' height='2.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='263.99' width='8.82' height='0.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='262.03' width='8.82' height='1.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='263.99' width='8.82' height='0.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='263.99' width='8.82' height='1.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='263.41' width='8.82' height='0.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='261.54' width='8.82' height='2.45' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='259.19' width='8.82' height='4.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='256.82' width='8.82' height='7.17' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='259.94' width='8.82' height='4.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='263.99' width='8.82' height='0.017' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='261.16' width='8.82' height='2.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='259.94' width='8.82' height='4.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='263.90' width='8.82' height='0.090' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='262.30' width='8.82' height='1.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='209.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='438.05' width='8.82' height='86.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='468.73' width='8.82' height='56.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='487.17' width='8.82' height='37.68' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='500.98' width='8.82' height='23.87' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='507.27' width='8.82' height='17.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='513.94' width='8.82' height='10.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='519.29' width='8.82' height='5.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='520.29' width='8.82' height='4.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='522.24' width='8.82' height='2.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='524.85' width='8.82' height='0.0017' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='524.79' width='8.82' height='0.060' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='523.50' width='8.82' height='1.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='521.49' width='8.82' height='3.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='521.71' width='8.82' height='3.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='523.13' width='8.82' height='1.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='521.99' width='8.82' height='2.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='522.36' width='8.82' height='2.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='523.44' width='8.82' height='1.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='520.14' width='8.82' height='4.71' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='522.97' width='8.82' height='1.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='520.33' width='8.82' height='4.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='523.69' width='8.82' height='1.16' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='524.85' width='8.82' height='2.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='524.85' width='8.82' height='0.068' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='524.85' width='8.82' height='3.89' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='524.85' width='8.82' height='4.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='524.85' width='8.82' height='3.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='524.85' width='8.82' height='2.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='523.99' width='8.82' height='0.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='524.85' width='8.82' height='0.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='209.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='438.05' width='8.82' height='86.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='468.73' width='8.82' height='56.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='487.17' width='8.82' height='37.68' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='500.98' width='8.82' height='23.87' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='507.27' width='8.82' height='17.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='513.94' width='8.82' height='10.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='519.29' width='8.82' height='5.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='520.29' width='8.82' height='4.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='522.24' width='8.82' height='2.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='524.85' width='8.82' height='0.0017' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='524.79' width='8.82' height='0.060' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='523.50' width='8.82' height='1.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='521.49' width='8.82' height='3.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='521.71' width='8.82' height='3.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='523.13' width='8.82' height='1.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='521.99' width='8.82' height='2.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='522.36' width='8.82' height='2.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='523.44' width='8.82' height='1.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='520.14' width='8.82' height='4.71' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='522.97' width='8.82' height='1.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='520.33' width='8.82' height='4.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='523.69' width='8.82' height='1.16' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='524.85' width='8.82' height='2.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='524.85' width='8.82' height='0.068' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='524.85' width='8.82' height='3.89' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='524.85' width='8.82' height='4.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='524.85' width='8.82' height='3.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='524.85' width='8.82' height='2.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='523.99' width='8.82' height='0.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='524.85' width='8.82' height='0.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-7.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-7.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='211.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='228.30' width='8.82' height='37.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='247.12' width='8.82' height='18.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='256.21' width='8.82' height='9.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='260.25' width='8.82' height='5.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='263.60' width='8.82' height='2.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='265.74' width='8.82' height='1.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='265.74' width='8.82' height='1.39' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='265.74' width='8.82' height='3.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='265.74' width='8.82' height='1.87' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='262.96' width='8.82' height='2.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='263.87' width='8.82' height='1.87' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='263.35' width='8.82' height='2.38' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='262.33' width='8.82' height='3.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='263.43' width='8.82' height='2.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='265.74' width='8.82' height='1.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='265.74' width='8.82' height='0.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='265.74' width='8.82' height='4.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='265.74' width='8.82' height='2.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='265.74' width='8.82' height='3.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='265.74' width='8.82' height='2.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='265.74' width='8.82' height='2.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='265.74' width='8.82' height='0.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='265.39' width='8.82' height='0.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='263.74' width='8.82' height='1.99' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='258.04' width='8.82' height='7.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='262.92' width='8.82' height='2.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='262.73' width='8.82' height='3.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='261.19' width='8.82' height='4.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='258.80' width='8.82' height='6.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='259.45' width='8.82' height='6.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='211.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='228.30' width='8.82' height='37.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='247.12' width='8.82' height='18.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='256.21' width='8.82' height='9.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='260.25' width='8.82' height='5.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='263.60' width='8.82' height='2.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='265.74' width='8.82' height='1.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='265.74' width='8.82' height='1.39' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='265.74' width='8.82' height='3.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='265.74' width='8.82' height='1.87' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='262.96' width='8.82' height='2.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='263.87' width='8.82' height='1.87' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='263.35' width='8.82' height='2.38' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='262.33' width='8.82' height='3.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='263.43' width='8.82' height='2.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='265.74' width='8.82' height='1.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='265.74' width='8.82' height='0.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='265.74' width='8.82' height='4.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='265.74' width='8.82' height='2.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='265.74' width='8.82' height='3.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='265.74' width='8.82' height='2.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='265.74' width='8.82' height='2.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='265.74' width='8.82' height='0.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='265.39' width='8.82' height='0.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='263.74' width='8.82' height='1.99' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='258.04' width='8.82' height='7.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='262.92' width='8.82' height='2.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='262.73' width='8.82' height='3.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='261.19' width='8.82' height='4.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='258.80' width='8.82' height='6.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='259.45' width='8.82' height='6.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='211.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='487.48' width='8.82' height='39.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='511.01' width='8.82' height='15.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='515.69' width='8.82' height='10.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='524.30' width='8.82' height='2.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='526.59' width='8.82' height='0.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='526.59' width='8.82' height='0.32' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='526.59' width='8.82' height='4.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='526.59' width='8.82' height='1.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='526.59' width='8.82' height='1.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='526.59' width='8.82' height='2.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='526.59' width='8.82' height='2.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='526.59' width='8.82' height='1.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='526.59' width='8.82' height='3.04' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='519.88' width='8.82' height='6.71' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='523.09' width='8.82' height='3.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='524.29' width='8.82' height='2.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='524.79' width='8.82' height='1.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='525.05' width='8.82' height='1.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='526.59' width='8.82' height='3.29' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='526.59' width='8.82' height='2.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='524.38' width='8.82' height='2.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='526.59' width='8.82' height='3.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='526.59' width='8.82' height='0.098' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='526.59' width='8.82' height='0.84' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='523.39' width='8.82' height='3.21' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='526.59' width='8.82' height='1.05' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='524.99' width='8.82' height='1.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='524.02' width='8.82' height='2.58' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='526.59' width='8.82' height='0.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='523.17' width='8.82' height='3.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='211.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='487.48' width='8.82' height='39.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='511.01' width='8.82' height='15.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='515.69' width='8.82' height='10.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='524.30' width='8.82' height='2.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='526.59' width='8.82' height='0.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='526.59' width='8.82' height='0.32' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='526.59' width='8.82' height='4.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='526.59' width='8.82' height='1.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='526.59' width='8.82' height='1.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='526.59' width='8.82' height='2.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='526.59' width='8.82' height='2.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='526.59' width='8.82' height='1.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='526.59' width='8.82' height='3.04' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='519.88' width='8.82' height='6.71' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='523.09' width='8.82' height='3.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='524.29' width='8.82' height='2.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='524.79' width='8.82' height='1.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='525.05' width='8.82' height='1.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='526.59' width='8.82' height='3.29' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='526.59' width='8.82' height='2.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='524.38' width='8.82' height='2.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='526.59' width='8.82' height='3.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='526.59' width='8.82' height='0.098' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='526.59' width='8.82' height='0.84' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='523.39' width='8.82' height='3.21' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='526.59' width='8.82' height='1.05' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='524.99' width='8.82' height='1.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='524.02' width='8.82' height='2.58' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='526.59' width='8.82' height='0.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='523.17' width='8.82' height='3.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='211.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='222.19' width='8.82' height='43.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='246.26' width='8.82' height='19.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='254.54' width='8.82' height='11.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='261.97' width='8.82' height='3.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='264.49' width='8.82' height='1.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='265.74' width='8.82' height='0.057' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='264.40' width='8.82' height='1.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='264.93' width='8.82' height='0.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='264.14' width='8.82' height='1.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='265.64' width='8.82' height='0.097' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='265.74' width='8.82' height='4.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='265.74' width='8.82' height='1.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='265.74' width='8.82' height='4.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='264.07' width='8.82' height='1.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='262.07' width='8.82' height='3.66' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='263.37' width='8.82' height='2.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='263.48' width='8.82' height='2.25' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='264.66' width='8.82' height='1.08' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='265.64' width='8.82' height='0.093' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='265.74' width='8.82' height='0.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='265.74' width='8.82' height='0.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='265.74' width='8.82' height='1.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='265.74' width='8.82' height='0.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='262.68' width='8.82' height='3.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='262.02' width='8.82' height='3.72' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='264.85' width='8.82' height='0.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='265.65' width='8.82' height='0.085' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='265.30' width='8.82' height='0.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='264.45' width='8.82' height='1.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='260.73' width='8.82' height='5.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='211.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='222.19' width='8.82' height='43.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='246.26' width='8.82' height='19.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='254.54' width='8.82' height='11.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='261.97' width='8.82' height='3.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='264.49' width='8.82' height='1.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='265.74' width='8.82' height='0.057' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='264.40' width='8.82' height='1.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='264.93' width='8.82' height='0.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='264.14' width='8.82' height='1.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='265.64' width='8.82' height='0.097' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='265.74' width='8.82' height='4.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='265.74' width='8.82' height='1.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='265.74' width='8.82' height='4.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='264.07' width='8.82' height='1.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='262.07' width='8.82' height='3.66' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='263.37' width='8.82' height='2.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='263.48' width='8.82' height='2.25' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='264.66' width='8.82' height='1.08' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='265.64' width='8.82' height='0.093' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='265.74' width='8.82' height='0.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='265.74' width='8.82' height='0.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='265.74' width='8.82' height='1.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='265.74' width='8.82' height='0.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='262.68' width='8.82' height='3.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='262.02' width='8.82' height='3.72' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='264.85' width='8.82' height='0.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='265.65' width='8.82' height='0.085' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='265.30' width='8.82' height='0.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='264.45' width='8.82' height='1.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='260.73' width='8.82' height='5.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='211.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='485.17' width='8.82' height='41.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='510.18' width='8.82' height='16.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='519.19' width='8.82' height='7.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='525.69' width='8.82' height='0.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='526.49' width='8.82' height='0.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='526.59' width='8.82' height='5.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='526.59' width='8.82' height='4.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='526.59' width='8.82' height='0.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='526.59' width='8.82' height='3.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='526.50' width='8.82' height='0.093' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='526.59' width='8.82' height='0.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='526.59' width='8.82' height='1.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='522.52' width='8.82' height='4.07' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='522.40' width='8.82' height='4.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='526.59' width='8.82' height='1.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='526.59' width='8.82' height='3.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='526.59' width='8.82' height='0.75' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='526.59' width='8.82' height='3.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='524.15' width='8.82' height='2.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='523.40' width='8.82' height='3.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='526.23' width='8.82' height='0.37' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='522.64' width='8.82' height='3.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='526.59' width='8.82' height='0.077' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='526.59' width='8.82' height='1.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='526.59' width='8.82' height='1.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='526.59' width='8.82' height='0.81' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='524.50' width='8.82' height='2.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='526.59' width='8.82' height='2.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='526.59' width='8.82' height='0.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='526.59' width='8.82' height='1.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='211.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='485.17' width='8.82' height='41.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='510.18' width='8.82' height='16.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='519.19' width='8.82' height='7.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='525.69' width='8.82' height='0.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='526.49' width='8.82' height='0.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='526.59' width='8.82' height='5.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='526.59' width='8.82' height='4.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='526.59' width='8.82' height='0.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='526.59' width='8.82' height='3.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='526.50' width='8.82' height='0.093' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='526.59' width='8.82' height='0.45' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='526.59' width='8.82' height='1.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='522.52' width='8.82' height='4.07' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='522.40' width='8.82' height='4.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='526.59' width='8.82' height='1.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='526.59' width='8.82' height='3.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='526.59' width='8.82' height='0.75' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='526.59' width='8.82' height='3.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='524.15' width='8.82' height='2.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='523.40' width='8.82' height='3.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='526.23' width='8.82' height='0.37' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='522.64' width='8.82' height='3.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='526.59' width='8.82' height='0.077' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='526.59' width='8.82' height='1.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='526.59' width='8.82' height='1.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='526.59' width='8.82' height='0.81' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='524.50' width='8.82' height='2.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='526.59' width='8.82' height='2.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='526.59' width='8.82' height='0.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='526.59' width='8.82' height='1.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>

--- a/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-8.svg
+++ b/tests/testthat/_snaps/4-diagnostics/diagnostics-sigma-8.svg
@@ -27,37 +27,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDQzLjczfDI4Mi40Ng==)'>
 <rect x='42.87' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='54.58' width='8.82' height='209.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='164.07' width='8.82' height='99.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='193.97' width='8.82' height='70.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='215.47' width='8.82' height='48.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='227.91' width='8.82' height='36.07' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='234.39' width='8.82' height='29.60' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='238.40' width='8.82' height='25.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='243.05' width='8.82' height='20.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='246.28' width='8.82' height='17.70' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='247.50' width='8.82' height='16.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='253.12' width='8.82' height='10.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='254.48' width='8.82' height='9.51' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='258.04' width='8.82' height='5.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='261.03' width='8.82' height='2.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='263.99' width='8.82' height='0.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='263.99' width='8.82' height='1.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='263.99' width='8.82' height='4.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='263.99' width='8.82' height='3.55' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='263.99' width='8.82' height='3.15' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='263.99' width='8.82' height='4.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='263.99' width='8.82' height='3.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='263.99' width='8.82' height='3.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='263.99' width='8.82' height='5.82' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='263.99' width='8.82' height='7.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='263.99' width='8.82' height='2.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='263.99' width='8.82' height='2.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='263.99' width='8.82' height='2.91' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='263.99' width='8.82' height='0.35' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='263.99' width='8.82' height='2.23' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='263.99' width='8.82' height='1.49' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='263.99' width='8.82' height='3.94' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='54.58' width='8.82' height='209.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='164.07' width='8.82' height='99.92' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='193.97' width='8.82' height='70.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='215.47' width='8.82' height='48.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='227.91' width='8.82' height='36.07' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='234.39' width='8.82' height='29.60' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='238.40' width='8.82' height='25.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='243.05' width='8.82' height='20.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='246.28' width='8.82' height='17.70' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='247.50' width='8.82' height='16.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='253.12' width='8.82' height='10.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='254.48' width='8.82' height='9.51' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='258.04' width='8.82' height='5.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='261.03' width='8.82' height='2.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='263.99' width='8.82' height='0.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='263.99' width='8.82' height='1.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='263.99' width='8.82' height='4.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='263.99' width='8.82' height='3.55' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='263.99' width='8.82' height='3.15' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='263.99' width='8.82' height='4.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='263.99' width='8.82' height='3.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='263.99' width='8.82' height='3.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='263.99' width='8.82' height='5.82' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='263.99' width='8.82' height='7.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='263.99' width='8.82' height='2.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='263.99' width='8.82' height='2.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='263.99' width='8.82' height='2.91' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='263.99' width='8.82' height='0.35' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='263.99' width='8.82' height='2.23' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='263.99' width='8.82' height='1.49' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='263.99' width='8.82' height='3.94' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -68,37 +68,37 @@
 </defs>
 <g clip-path='url(#cpNDIuODd8Mzc1Ljk2fDMwNC41OXw1NDMuMzI=)'>
 <rect x='42.87' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='58.01' y='315.44' width='8.82' height='209.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='67.81' y='439.82' width='8.82' height='85.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='77.61' y='469.92' width='8.82' height='54.93' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='87.41' y='489.41' width='8.82' height='35.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='97.21' y='505.39' width='8.82' height='19.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='107.01' y='511.97' width='8.82' height='12.87' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='116.81' y='513.70' width='8.82' height='11.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='126.61' y='521.35' width='8.82' height='3.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='136.41' y='522.11' width='8.82' height='2.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='146.21' y='524.84' width='8.82' height='0.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='156.01' y='524.84' width='8.82' height='0.31' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='165.81' y='524.29' width='8.82' height='0.56' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='175.61' y='524.84' width='8.82' height='0.10' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='185.41' y='522.41' width='8.82' height='2.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='195.21' y='524.73' width='8.82' height='0.12' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='205.01' y='522.21' width='8.82' height='2.64' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='214.81' y='519.85' width='8.82' height='5.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='224.60' y='524.15' width='8.82' height='0.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='234.40' y='524.84' width='8.82' height='2.69' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='244.20' y='524.84' width='8.82' height='2.09' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='254.00' y='524.84' width='8.82' height='1.54' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='263.80' y='524.84' width='8.82' height='0.74' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='273.60' y='524.43' width='8.82' height='0.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='283.40' y='522.71' width='8.82' height='2.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='293.20' y='521.08' width='8.82' height='3.76' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='303.00' y='519.35' width='8.82' height='5.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='312.80' y='519.85' width='8.82' height='5.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='322.60' y='521.04' width='8.82' height='3.80' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='332.40' y='520.35' width='8.82' height='4.50' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='342.20' y='518.64' width='8.82' height='6.21' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='352.00' y='523.37' width='8.82' height='1.47' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='58.01' y='315.44' width='8.82' height='209.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='67.81' y='439.82' width='8.82' height='85.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='77.61' y='469.92' width='8.82' height='54.93' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='87.41' y='489.41' width='8.82' height='35.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='97.21' y='505.39' width='8.82' height='19.45' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='107.01' y='511.97' width='8.82' height='12.87' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='116.81' y='513.70' width='8.82' height='11.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='126.61' y='521.35' width='8.82' height='3.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='136.41' y='522.11' width='8.82' height='2.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='146.21' y='524.84' width='8.82' height='0.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='156.01' y='524.84' width='8.82' height='0.31' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='165.81' y='524.29' width='8.82' height='0.56' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='175.61' y='524.84' width='8.82' height='0.10' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='185.41' y='522.41' width='8.82' height='2.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='195.21' y='524.73' width='8.82' height='0.12' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='205.01' y='522.21' width='8.82' height='2.64' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='214.81' y='519.85' width='8.82' height='5.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='224.60' y='524.15' width='8.82' height='0.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='234.40' y='524.84' width='8.82' height='2.69' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='244.20' y='524.84' width='8.82' height='2.09' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='254.00' y='524.84' width='8.82' height='1.54' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='263.80' y='524.84' width='8.82' height='0.74' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='273.60' y='524.43' width='8.82' height='0.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='283.40' y='522.71' width='8.82' height='2.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='293.20' y='521.08' width='8.82' height='3.76' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='303.00' y='519.35' width='8.82' height='5.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='312.80' y='519.85' width='8.82' height='5.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='322.60' y='521.04' width='8.82' height='3.80' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='332.40' y='520.35' width='8.82' height='4.50' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='342.20' y='518.64' width='8.82' height='6.21' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='352.00' y='523.37' width='8.82' height='1.47' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -109,37 +109,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41Mnw0My43M3wyODIuNDY=)'>
 <rect x='381.44' y='43.73' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='54.58' width='8.82' height='209.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='162.88' width='8.82' height='101.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='193.87' width='8.82' height='70.11' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='211.99' width='8.82' height='52.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='225.71' width='8.82' height='38.28' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='239.54' width='8.82' height='24.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='250.03' width='8.82' height='13.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='256.72' width='8.82' height='7.26' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='258.99' width='8.82' height='5.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='256.06' width='8.82' height='7.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='257.10' width='8.82' height='6.88' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='260.92' width='8.82' height='3.07' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='262.47' width='8.82' height='1.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='260.21' width='8.82' height='3.78' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='260.13' width='8.82' height='3.86' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='262.85' width='8.82' height='1.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='262.56' width='8.82' height='1.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='260.80' width='8.82' height='3.19' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='260.77' width='8.82' height='3.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='257.65' width='8.82' height='6.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='259.24' width='8.82' height='4.75' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='260.25' width='8.82' height='3.73' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='263.65' width='8.82' height='0.34' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='260.59' width='8.82' height='3.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='259.45' width='8.82' height='4.53' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='263.47' width='8.82' height='0.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='261.56' width='8.82' height='2.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='263.99' width='8.82' height='1.14' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='263.55' width='8.82' height='0.44' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='262.40' width='8.82' height='1.59' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='263.99' width='8.82' height='1.20' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='54.58' width='8.82' height='209.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='162.88' width='8.82' height='101.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='193.87' width='8.82' height='70.11' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='211.99' width='8.82' height='52.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='225.71' width='8.82' height='38.28' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='239.54' width='8.82' height='24.45' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='250.03' width='8.82' height='13.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='256.72' width='8.82' height='7.26' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='258.99' width='8.82' height='5.00' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='256.06' width='8.82' height='7.92' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='257.10' width='8.82' height='6.88' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='260.92' width='8.82' height='3.07' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='262.47' width='8.82' height='1.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='260.21' width='8.82' height='3.78' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='260.13' width='8.82' height='3.86' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='262.85' width='8.82' height='1.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='262.56' width='8.82' height='1.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='260.80' width='8.82' height='3.19' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='260.77' width='8.82' height='3.22' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='257.65' width='8.82' height='6.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='259.24' width='8.82' height='4.75' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='260.25' width='8.82' height='3.73' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='263.65' width='8.82' height='0.34' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='260.59' width='8.82' height='3.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='259.45' width='8.82' height='4.53' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='263.47' width='8.82' height='0.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='261.56' width='8.82' height='2.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='263.99' width='8.82' height='1.14' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='263.55' width='8.82' height='0.44' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='262.40' width='8.82' height='1.59' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='263.99' width='8.82' height='1.20' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -150,37 +150,37 @@
 </defs>
 <g clip-path='url(#cpMzgxLjQ0fDcxNC41MnwzMDQuNTl8NTQzLjMy)'>
 <rect x='381.44' y='304.59' width='333.08' height='238.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='396.58' y='315.44' width='8.82' height='209.40' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='406.38' y='409.30' width='8.82' height='115.55' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='416.18' y='435.07' width='8.82' height='89.77' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='425.98' y='458.84' width='8.82' height='66.01' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='435.77' y='474.92' width='8.82' height='49.92' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='445.57' y='479.83' width='8.82' height='45.02' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='455.37' y='490.94' width='8.82' height='33.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='465.17' y='495.43' width='8.82' height='29.42' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='474.97' y='502.72' width='8.82' height='22.13' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='484.77' y='508.79' width='8.82' height='16.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='494.57' y='514.20' width='8.82' height='10.65' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='504.37' y='519.32' width='8.82' height='5.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='514.17' y='524.84' width='8.82' height='0.76' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='523.97' y='524.84' width='8.82' height='0.83' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='533.77' y='524.84' width='8.82' height='1.41' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='543.57' y='524.84' width='8.82' height='2.33' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='553.37' y='524.84' width='8.82' height='3.96' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='563.17' y='524.84' width='8.82' height='4.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='572.97' y='524.84' width='8.82' height='2.62' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='582.77' y='524.84' width='8.82' height='2.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='592.57' y='524.84' width='8.82' height='2.52' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='602.37' y='524.84' width='8.82' height='2.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='612.17' y='524.84' width='8.82' height='2.95' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='621.96' y='524.84' width='8.82' height='0.30' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='631.76' y='524.84' width='8.82' height='2.36' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='641.56' y='524.84' width='8.82' height='3.48' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='651.36' y='524.84' width='8.82' height='1.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='661.16' y='524.84' width='8.82' height='2.63' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='670.96' y='524.84' width='8.82' height='7.57' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='680.76' y='524.84' width='8.82' height='1.43' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
-<rect x='690.56' y='524.84' width='8.82' height='1.07' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='396.58' y='315.44' width='8.82' height='209.40' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='406.38' y='409.30' width='8.82' height='115.55' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='416.18' y='435.07' width='8.82' height='89.77' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='425.98' y='458.84' width='8.82' height='66.01' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='435.77' y='474.92' width='8.82' height='49.92' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='445.57' y='479.83' width='8.82' height='45.02' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='455.37' y='490.94' width='8.82' height='33.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='465.17' y='495.43' width='8.82' height='29.42' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='474.97' y='502.72' width='8.82' height='22.13' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='484.77' y='508.79' width='8.82' height='16.06' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='494.57' y='514.20' width='8.82' height='10.65' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='504.37' y='519.32' width='8.82' height='5.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='514.17' y='524.84' width='8.82' height='0.76' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='523.97' y='524.84' width='8.82' height='0.83' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='533.77' y='524.84' width='8.82' height='1.41' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='543.57' y='524.84' width='8.82' height='2.33' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='553.37' y='524.84' width='8.82' height='3.96' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='563.17' y='524.84' width='8.82' height='4.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='572.97' y='524.84' width='8.82' height='2.62' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='582.77' y='524.84' width='8.82' height='2.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='592.57' y='524.84' width='8.82' height='2.52' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='602.37' y='524.84' width='8.82' height='2.61' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='612.17' y='524.84' width='8.82' height='2.95' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='621.96' y='524.84' width='8.82' height='0.30' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='631.76' y='524.84' width='8.82' height='2.36' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='641.56' y='524.84' width='8.82' height='3.48' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='651.36' y='524.84' width='8.82' height='1.90' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='661.16' y='524.84' width='8.82' height='2.63' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='670.96' y='524.84' width='8.82' height='7.57' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='680.76' y='524.84' width='8.82' height='1.43' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
+<rect x='690.56' y='524.84' width='8.82' height='1.07' style='stroke-width: 6.40; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2001D;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
